### PR TITLE
fix: write workflow json before translating

### DIFF
--- a/wfcommons/wfbench/translator/abstract_translator.py
+++ b/wfcommons/wfbench/translator/abstract_translator.py
@@ -40,6 +40,8 @@ class Translator(ABC):
             instance = Instance(workflow, logger=logger)
             self.workflow = instance.workflow
 
+        self.workflow.write_json()
+
         # find all tasks
         self.tasks = {}
         for task in self.workflow.nodes.data():


### PR DESCRIPTION
## The Problem
When I try to generate a workflow and then translate it without ever having called `write_json()` on it, the Translator constructor throws this exception:
```python
AttributeError: 'Workflow' object has no attribute 'workflow_json'
```
Minimal example:
```python
from wfcommons import WorkflowGenerator
from wfcommons.wfchef.recipes.bwa import BwaRecipe
from wfcommons.wfbench.translator import PegasusTranslator

generator = WorkflowGenerator(BwaRecipe().from_num_tasks(250))
workflow = generator.build_workflow()
pegasus_translator = PegasusTranslator(workflow)
```
(but this also happens for workflows generated by `create_benchmark()` or `create_benchmark_from_input_file()`)

## A Solution
My simple solution was calling the `write_json()` in the constructor of `AbstractTranslator` but I am aware that this might not be the best solution.