### PR TITLE
Additions for Vampir workflow analysis

### DIFF
--- a/wfcommons/common/task.py
+++ b/wfcommons/common/task.py
@@ -10,6 +10,7 @@
 
 import logging
 
+from datetime import datetime
 from typing import Dict, List, Optional
 from logging import Logger
 
@@ -109,7 +110,7 @@ class Task:
         self.machine: Machine = machine
         self.priority: Optional[int] = priority
         self.launch_dir: Optional[str] = launch_dir
-        self.start_time: Optional[str] = start_time
+        self.start_time: Optional[str] = str(datetime.now().astimezone().isoformat()) if not start_time else start_time
         self.logger.debug(
             f"created {self.type} task {self.name}: runtime => {self.runtime} seconds.")
 
@@ -160,7 +161,7 @@ class Task:
         if self.machine:
             task_obj['machine'] = self.machine.name
         if self.launch_dir:
-            task_obj['launch_dir'] = self.launch_dir
+            task_obj['launchDir'] = self.launch_dir
         if self.start_time:
-            task_obj['start_time'] = self.start_time
+            task_obj['startedAt'] = self.start_time
         return task_obj

--- a/wfcommons/common/task.py
+++ b/wfcommons/common/task.py
@@ -84,7 +84,9 @@ class Task:
                  avg_power: Optional[float] = None,
                  priority: Optional[int] = None,
                  files: Optional[List[File]] = None,
-                 logger: Optional[Logger] = None
+                 logger: Optional[Logger] = None,
+                 launch_dir: Optional[str] = None,
+                 start_time: Optional[str] = None,
                  ) -> None:
         """A task in a workflow."""
         self.logger: Logger = logging.getLogger(
@@ -106,7 +108,8 @@ class Task:
         self.files: List[File] = files if files else []
         self.machine: Machine = machine
         self.priority: Optional[int] = priority
-
+        self.launch_dir: Optional[str] = launch_dir
+        self.start_time: Optional[str] = start_time
         self.logger.debug(
             f"created {self.type} task {self.name}: runtime => {self.runtime} seconds.")
 
@@ -156,5 +159,8 @@ class Task:
             task_obj['command']['arguments'] = self.args
         if self.machine:
             task_obj['machine'] = self.machine.name
-
+        if self.launch_dir:
+            task_obj['launch_dir'] = self.launch_dir
+        if self.start_time:
+            task_obj['start_time'] = self.start_time
         return task_obj

--- a/wfcommons/common/workflow.py
+++ b/wfcommons/common/workflow.py
@@ -60,7 +60,7 @@ class Workflow(nx.DiGraph):
         self.wms_name: Optional[str] = "WfCommons" if not wms_name else wms_name
         self.wms_version: Optional[str] = str(__version__) if not wms_version else wms_version
         self.wms_url: Optional[str] = f"https://docs.wfcommons.org/en/v{__version__}/" if not wms_url else wms_url
-        self.executed_at: Optional[str] = datetime.now().astimezone().isoformat() if not executed_at else executed_at
+        self.executed_at: Optional[str] = str(datetime.now().astimezone().isoformat()) if not executed_at else executed_at
         self.makespan: Optional[int] = makespan
         self.tasks = {}
         self.tasks_parents = {}

--- a/wfcommons/common/workflow.py
+++ b/wfcommons/common/workflow.py
@@ -60,7 +60,7 @@ class Workflow(nx.DiGraph):
         self.wms_name: Optional[str] = "WfCommons" if not wms_name else wms_name
         self.wms_version: Optional[str] = str(__version__) if not wms_version else wms_version
         self.wms_url: Optional[str] = f"https://docs.wfcommons.org/en/v{__version__}/" if not wms_url else wms_url
-        self.executed_at: Optional[str] = datetime.now().astimezone().isoformat()) if not executed_at else executed_at
+        self.executed_at: Optional[str] = datetime.now().astimezone().isoformat() if not executed_at else executed_at
         self.makespan: Optional[int] = makespan
         self.tasks = {}
         self.tasks_parents = {}


### PR DESCRIPTION
Developing Vampir's post-mortem workflow analysis capability leads us to propose two new fields in wfcommons tasks:
1. A launch directory, so it knows where to look for Score-P output
2. A start time, so that it can present how the workflow executed as a coherent timeline

Unrelated, but has managed to sneak in here anyway: there was a typo in my PR for using ISO date-time uniformly, which is fixed in the changes to workflows.py.