### PR TITLE
Nextflow Translator

### DIFF
--- a/docs/source/dev_api_wfbench.rst
+++ b/docs/source/dev_api_wfbench.rst
@@ -13,6 +13,16 @@ wfcommons.wfbench.bench
    :show-inheritance:
    :private-members:
    :noindex:
+ 
+wfcommons.wfbench.translator.nextflow
+------------------------------------
+
+.. automodule:: wfcommons.wfbench.translator.nextflow
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:
+   :noindex:
 
 wfcommons.wfbench.translator.pegasus
 ------------------------------------

--- a/docs/source/generating_workflow_benchmarks.rst
+++ b/docs/source/generating_workflow_benchmarks.rst
@@ -67,6 +67,35 @@ description in :ref:`json-format-label`.
     to execute memory-intensive threads. Therefore, it is crucial to ensure that 
     :code:`stress-ng` is installed on all worker nodes.
 
+Nextflow
+++++++++
+`Nextflow <https://www.nextflow.io/>`_ is a workflow management system that enables
+the development of portable and reproducible workflows. It supports deploying workflows
+on a variety of execution platforms including local, HPC schedulers, and cloud-based
+and container-based environments. Below, we provide an example on how to generate
+workflow benchmark for running with Nextflow:
+
+    import pathlib
+
+    from wfcommons import BlastRecipe
+    from wfcommons.wfbench import WorkflowBenchmark, NextflowTranslator
+
+    # create a workflow benchmark object to generate specifications based on a recipe
+    benchmark = WorkflowBenchmark(recipe=BlastRecipe, num_tasks=500)
+
+    # generate a specification based on performance characteristics
+    benchmark.create_benchmark(pathlib.Path("/tmp/"), cpu_work=100, data=10, percent_cpu=0.6)
+
+    # generate a Nextflow workflow
+    translator = NextflowTranslator(benchmark.workflow)
+    translator.translate(output_file_name=pathlib.Path("/tmp/benchmark-workflow.nf"))
+
+.. warning::
+
+    Nextflow's way of defining workflows does not support tasks with iterations i.e. tasks 
+    that depend on another instance of the same abstract task. Thus, the translator
+    fails when you try to translate a workflow with iterations.
+
 Pegasus
 +++++++
 

--- a/docs/source/user_api_wfbench.rst
+++ b/docs/source/user_api_wfbench.rst
@@ -14,6 +14,13 @@ wfcommons.wfbench.bench
    :undoc-members:
    :show-inheritance:
 
+wfcommons.wfbench.translator.nextflow
+-------------------------------------
+
+.. automodule:: wfcommons.wfbench.translator.nextflow
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 wfcommons.wfbench.translator.pegasus
 ------------------------------------

--- a/wfcommons/wfbench/translator/__init__.py
+++ b/wfcommons/wfbench/translator/__init__.py
@@ -11,3 +11,4 @@
 from .dask import DaskTranslator
 from .pegasus import PegasusTranslator
 from .swift_t import SwiftTTranslator
+from .nextflow import NextflowTranslator

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021-2022 The WfCommons Team.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+import pathlib
+
+from logging import Logger
+from typing import Dict, List, Optional, Union
+
+from .abstract_translator import Translator
+from ...common import FileLink, Workflow
+from ...common.task import Task
+
+class NextflowTranslator(Translator):
+    """
+    A WfFormat parser for creating Nextflow workflow applications.
+
+    :param workflow: Workflow benchmark object or path to the workflow benchmark JSON instance.
+    :type workflow: Union[Workflow, pathlib.Path],
+    :param logger: The logger where to log information/warning or errors (optional).
+    :type logger: Logger
+    """
+
+    def __init__(self,
+                 workflow: Union[Workflow, pathlib.Path],
+                 logger: Optional[Logger] = None) -> None:
+        """Create an object of the translator."""
+        super().__init__(workflow, logger)
+
+        self.script = "nextflow.enable.dsl=2\n\n"
+
+    def translate(self, output_file_path: pathlib.Path) -> None:
+        """
+        Translate a workflow benchmark description (WfFormat) into a Nextflow workflow application.
+
+        :param output_file_path: The name of the output file (e.g., workflow.py).
+        :type output_file_path: pathlib.Path
+        """
+        
+        self.all_inputs = []
+        self.all_outputs = []
+        self.task_inputs: Dict[str, List[str]] = {}
+        self.task_outputs: Dict[str, List[str]] = {}
+        
+        task_written: Dict[str, bool] = {}
+        for task in self.tasks.values():
+            task_written[task.name] = False
+            self._add_task(task)
+
+        self.workflow_inputs = [i for i in self.all_inputs if i not in self.all_outputs]
+        self.workflow_outputs = [o for o in self.all_outputs if o not in self.all_outputs]
+        
+        self.script += "workflow {\n"
+        self.script += "    data = channel.fromPath('./inputs/*')\n"
+
+        def _write_task(task_name: str, inputs: List[str]):
+            task_params = []
+            for parent in self.task_parents[task_name]:
+                if not task_written[parent]:
+                    _write_task(parent, self.task_inputs[parent])
+            i = 0
+            for input_name in self.task_inputs[task_name]:
+                for parent in self.task_parents[task_name]:
+                    if input_name in self.task_outputs[parent]:
+                        task_params.append(f"{parent}_out.get({self.task_outputs[parent].index(input_name)})")
+                        break
+                else:
+                    if input_name in self.workflow_inputs:
+                        continue
+                    varname = f"{task_name}_in{i}"
+                    i += 1
+                    self.script += f"    file('{input_name.replace('-', '_')}').text = \"=== FILE {input_name.replace('-', '_')} ===\"\n"
+                    self.script += f"    {varname.replace('-', '_')} = channel.fromPath(file('{input_name.replace('-', '_')}'))\n"
+                    task_params.append(varname)
+            if not set(self.workflow_inputs).isdisjoint(inputs):
+                task_params.append("data")
+            task_params = {param.replace('-', '_') for param in task_params}
+            self.script += f"    {task_name.replace('-', '_')}_out = {task_name.replace('-', '_')}({', '.join(task_params)})\n"
+            task_written[task_name] = True
+
+        for task_name, inputs in self.task_inputs.items():
+            if not task_written[task_name]:
+                _write_task(task_name, inputs)
+
+        self.script += "}\n"
+
+        # write script to file
+        self._write_output_file(self.script, output_file_path)
+
+    def _add_task(self, task: Task) -> None:
+        """
+        Add a task to the workflow.
+
+        :param task: the task
+        :type task: Task
+        """
+
+        input_files = [file.name for file in task.files if file.link == FileLink.INPUT]
+        output_files = [file.name for file in task.files if file.link == FileLink.OUTPUT]
+        self.all_inputs.extend(input_files)
+        self.all_outputs.extend(output_files)
+    
+        self.script += f"process {task.name.replace('-', '_')}" + " {\n"
+        if task.cores:
+            self.script += f"  cpus {task.cores+1}\n"
+        if task.memory:
+            self.script += f"  memory {task.memory}\n"
+        else:
+            self.script += f"  memory 10.GB\n"
+        self.script += "  errorStrategy { task.exitStatus=143 ? 'ignore' : 'terminate' }\n\n"
+        self.script += "  input:\n"
+        for input_file in input_files:
+            self.script += f"    path \"{input_file}\"\n"
+        self.script += "  output:\n"
+        for output_file in output_files:
+            self.script += f"    path \"{output_file}\"\n"
+        self.script += "\n"
+        self.script += "  script:\n"
+        self.script += "  \"\"\"\n"
+        self.script += f"  {pathlib.Path(task.program).name}"
+        for a in task.args:
+            self.script += ' '
+            a = a.replace("'", "\"") if "--out" not in a else a.replace("{", "\"{").replace("}", "}\"").replace("'", "\\\\\"").replace(": ", ":")
+            self.script += a
+        self.script += '\n'
+        self.script += "  \"\"\"\n"
+        self.script += "}\n"
+
+        self.task_inputs[task.name] = input_files
+        self.task_outputs[task.name] = output_files
+

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -9,13 +9,16 @@
 # (at your option) any later version.
 
 import pathlib
+import re
 
+from collections import defaultdict
 from logging import Logger
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, MutableSet
 
 from .abstract_translator import Translator
 from ...common import FileLink, Workflow
 from ...common.task import Task
+
 
 class NextflowTranslator(Translator):
     """
@@ -33,105 +36,235 @@ class NextflowTranslator(Translator):
         """Create an object of the translator."""
         super().__init__(workflow, logger)
 
-        self.script = "nextflow.enable.dsl=2\n\n"
+        self.script = """
+String extractIDfromFile(Path filepath, String task_name) {
+  String filename = filepath as String
+  filename = filename[filename.lastIndexOf('/')+1..-1]
+  
+  int first_id_start = filename.indexOf('0')
+  if (first_id_start < 0) return
+  String first_task_name = filename.substring(0, first_id_start - 1)
+  if (first_task_name == task_name) return filename.substring(first_id_start, first_id_start + 8)
 
-    def translate(self, output_file_path: pathlib.Path) -> None:
-        """
-        Translate a workflow benchmark description (WfFormat) into a Nextflow workflow application.
+  if (first_id_start + 9 >= filename.length()) return
 
-        :param output_file_path: The name of the output file (e.g., workflow.py).
-        :type output_file_path: pathlib.Path
+  int second_id_start = filename.indexOf('0', first_id_start + 8)
+  if (second_id_start < 0) return
+  String second_task_name = filename.substring(first_id_start + 9, second_id_start - 1)
+  if (second_task_name == task_name) return filename.substring(second_id_start, second_id_start + 8)
+}
+
+"""
+
+    def translate(self, output_file_path: pathlib.Path, input_file_directory: pathlib.Path = None) -> None:
         """
-        
-        self.all_inputs = []
-        self.all_outputs = []
+        Translate a workflow benchmark description(WfFormat) into a Nextflow workflow application.
+
+        : param output_file_path: The name of the output file(e.g., workflow.py).
+        : type output_file_path: pathlib.Path
+        """
+
         self.task_inputs: Dict[str, List[str]] = {}
         self.task_outputs: Dict[str, List[str]] = {}
-        
-        task_written: Dict[str, bool] = {}
-        for task in self.tasks.values():
-            task_written[task.name] = False
-            self._add_task(task)
 
-        self.workflow_inputs = [i for i in self.all_inputs if i not in self.all_outputs]
-        self.workflow_outputs = [o for o in self.all_outputs if o not in self.all_outputs]
-        
+        self.missing_files = []
+
+        # determine the abstract tasks and their abstract parents and children
+        self.abstract_tasks = defaultdict(list)
+        self.abstract_children: Dict[str, MutableSet[str]] = defaultdict(set)
+        self.abstract_parents: Dict[str, MutableSet[str]] = defaultdict(set)
+        self._determine_abstract_tasks()
+
+        all_inputs = []
+        all_outputs = []
+        for inputs in self.task_inputs.values():
+            all_inputs.extend(inputs)
+        for outputs in self.task_outputs.values():
+            all_outputs.extend(outputs)
+        self.workflow_inputs = [i for i in all_inputs if i not in all_outputs]
+
+        self.task_outstreams: Dict = {}
+        for abstract_task_name, physical_tasks in self.abstract_tasks.items():
+            self._add_output_map(abstract_task_name, physical_tasks)
+        self.task_written: Dict[str, bool] = {}
+        for abstract_task_name, physical_tasks in self.abstract_tasks.items():
+            self.task_written[abstract_task_name] = False
+            self._add_abstract_task(abstract_task_name, physical_tasks)
+
         self.script += "workflow {\n"
-        self.script += "    data = channel.fromPath('./inputs/*')\n"
+        workflow_inputs_path: str = input_file_directory.absolute() if input_file_directory else pathlib.Path("./")
+        for missing_file in self.missing_files:
+            self.script += f"  file(\"{workflow_inputs_path.joinpath(missing_file)}\").text = \"?\"\n"
+        self.script += "\n"
 
-        def _write_task(task_name: str, inputs: List[str]):
-            task_params = []
-            for parent in self.task_parents[task_name]:
-                if not task_written[parent]:
-                    _write_task(parent, self.task_inputs[parent])
-            i = 0
-            for input_name in self.task_inputs[task_name]:
-                for parent in self.task_parents[task_name]:
-                    if input_name in self.task_outputs[parent]:
-                        task_params.append(f"{parent}_out.get({self.task_outputs[parent].index(input_name)})")
-                        break
-                else:
-                    if input_name in self.workflow_inputs:
-                        continue
-                    varname = f"{task_name}_in{i}"
-                    i += 1
-                    self.script += f"    file('{input_name.replace('-', '_')}').text = \"=== FILE {input_name.replace('-', '_')} ===\"\n"
-                    self.script += f"    {varname.replace('-', '_')} = channel.fromPath(file('{input_name.replace('-', '_')}'))\n"
-                    task_params.append(varname)
-            if not set(self.workflow_inputs).isdisjoint(inputs):
-                task_params.append("data")
-            task_params = {param.replace('-', '_') for param in task_params}
-            self.script += f"    {task_name.replace('-', '_')}_out = {task_name.replace('-', '_')}({', '.join(task_params)})\n"
-            task_written[task_name] = True
+        self.script += f"  workflow_inputs = Channel.fromPath(\"{workflow_inputs_path.joinpath('*')}\")\n"
+        self.script += "\n"
 
-        for task_name, inputs in self.task_inputs.items():
-            if not task_written[task_name]:
-                _write_task(task_name, inputs)
+        for abstract_task_name, physical_tasks in self.abstract_tasks.items():
+            if not self.task_written[abstract_task_name]:
+                self._write_abstract_task(abstract_task_name, physical_tasks)
 
         self.script += "}\n"
 
         # write script to file
         self._write_output_file(self.script, output_file_path)
 
-    def _add_task(self, task: Task) -> None:
-        """
-        Add a task to the workflow.
+    def _add_output_map(self, abstract_task_name: str, physical_tasks: List[Task]) -> None:
+        self.script += f"def {self.valid_task_name(abstract_task_name)}_out_args = [\n"
+        for ptask in physical_tasks:
+            out_args = [arg for arg in ptask.args if arg.startswith("--out ")]
+            assert (len(out_args) == 1)
+            out_arg = out_args[0].replace("--out {", "").replace("}", "").replace("'", "\\\\\\\"").replace(": ", ":")
+            self.script += f"  \"{ptask.task_id}\": \"{out_arg}\",\n"
+        self.script += "]\n\n"
 
-        :param task: the task
-        :type task: Task
-        """
+    def valid_task_name(self, original_task_name: str) -> str:
+        return original_task_name.replace('-', '_')
 
-        input_files = [file.name for file in task.files if file.link == FileLink.INPUT]
-        output_files = [file.name for file in task.files if file.link == FileLink.OUTPUT]
-        self.all_inputs.extend(input_files)
-        self.all_outputs.extend(output_files)
-    
-        self.script += f"process {task.name.replace('-', '_')}" + " {\n"
-        if task.cores:
-            self.script += f"  cpus {task.cores+1}\n"
-        if task.memory:
-            self.script += f"  memory {task.memory}\n"
+    def _write_abstract_task(self, abstract_task_name: str, physical_tasks: List[Task]) -> None:
+        parents = self.abstract_parents[abstract_task_name]
+        for parent in parents:
+            if parent == abstract_task_name:
+                continue
+            if not self.task_written[parent]:
+                self._write_abstract_task(parent, self.abstract_tasks[parent])
+
+        # determining the channel of all raw inputs (outputs of other tasks)
+        input_channels = [
+            f"{self.valid_task_name(parent)}_FOR_{self.valid_task_name(abstract_task_name)}" for parent in parents]
+        example_task = physical_tasks[0]
+        for input_file in self.task_inputs[example_task.name]:
+            if input_file in self.workflow_inputs or input_file in self.missing_files:
+                input_channels.append("workflow_inputs")
+                break
+
+        if len(input_channels) == 1:
+            inputs_channel = input_channels[0]
+        elif len(input_channels) != 0:
+            # concatenating all the input channels into one big channel
+            one_channel = input_channels.pop()
+            inputs_channel = f"concatenated_FOR_{self.valid_task_name(abstract_task_name)}"
+            self.script += f"  {inputs_channel} = {one_channel}.concat({', '.join(input_channels)})\n"
         else:
-            self.script += f"  memory 10.GB\n"
-        self.script += "  errorStrategy { task.exitStatus=143 ? 'ignore' : 'terminate' }\n\n"
+            raise RuntimeError(f"The abstract task {abstract_task_name} has no inputs.")
+
+        # creating the input channel for this abstract task by grouping the outputs from the parents by id
+        self.script += f"  {self.valid_task_name(abstract_task_name)}_in = {inputs_channel}.flatten().map{{\n"
+        self.script += f"    String id = extractIDfromFile(it, \"{abstract_task_name}\")\n"
+        self.script += f"    if (id) return [id, it]\n"
+        self.script += "  }.groupTuple()\n"
+
+        # creating one output channel for each child
+        out_channels = [f"{self.valid_task_name(abstract_task_name)}_FOR_{self.valid_task_name(name)}" for name,
+                        _ in self.task_outstreams[abstract_task_name]]
+        self.script += "  "
+        if len(out_channels) == 1:
+            self.script += f"{out_channels[0]} = "
+        elif len(out_channels) > 1:
+            self.script += f"({', '.join(out_channels)}) = "
+        self.script += f"task_{self.valid_task_name(abstract_task_name)}({self.valid_task_name(abstract_task_name)}_in)\n\n"
+
+        self.task_written[abstract_task_name] = True
+
+    def _determine_abstract_tasks(self) -> None:
+        """
+        Determines the abstract tasks that will be used for the nextflow definition of the workflow.
+        """
+
+        abstract_input_amounts = defaultdict(list)
+        abstract_output_amounts = defaultdict(list)
+
+        tasks_with_iterations = set()
+        for task in self.tasks.values():
+            abstract_task: str = task.category
+            self.abstract_tasks[abstract_task].append(task)
+            self.task_inputs[task.name] = [file.name for file in task.files if file.link == FileLink.INPUT]
+            self.task_outputs[task.name] = [file.name for file in task.files if file.link == FileLink.OUTPUT]
+            self.missing_files.extend([filename for filename in self.task_inputs[task.name]
+                                       if filename in self.task_outputs[task.name]])
+            abstract_input_amounts[abstract_task].append(len(self.task_inputs[task.name]))
+            abstract_output_amounts[abstract_task].append(len(self.task_outputs[task.name]))
+
+            for child in self.task_children[task.name]:
+                abstract_child: str = self.tasks[child].category
+                if abstract_child == abstract_task:
+                    tasks_with_iterations.add(abstract_task)
+                self.abstract_children[abstract_task].add(abstract_child)
+            for parent in self.task_parents[task.name]:
+                abstract_parent: str = self.tasks[parent].category
+                if abstract_parent == abstract_task:
+                    tasks_with_iterations.add(abstract_task)
+                self.abstract_parents[abstract_task].add(abstract_parent)
+
+        if tasks_with_iterations:
+            error_msg: str = "Iterations are not supported by Nextflow. "\
+                "Thus, this workflow has no Nextflow translation since the following "\
+                f"{'task uses' if len(tasks_with_iterations) == 1 else 'tasks use'} "\
+                "iterations:\n    "
+            error_msg += ", ".join(tasks_with_iterations)
+            raise RuntimeError(error_msg)
+
+    def _add_abstract_task(self, abstract_task_name: str, physical_tasks: List[Task]) -> None:
+        """
+        Add an abstract task to the workflow considering it's physical tasks.
+
+        : param abstract_task_name: the name of the abstract task
+        : type abstract_task_name: str
+        : param physical_tasks: a list of physical tasks for this abstract tasks
+        : type physical_tasks: List[Task]
+        """
+
+        cores_values = [task.cores for task in physical_tasks if task.cores]
+        cores = max(cores_values) if cores_values else None
+        memory_values = [task.memory for task in physical_tasks if task.memory]
+        memory = f"{max(memory_values)}.KB" if memory_values else "8.GB"
+
+        self.script += f"process task_{self.valid_task_name(abstract_task_name)}" + " {\n"
+        if cores:
+            self.script += f"  cpus {cores}\n"
+        if memory:
+            self.script += f"  memory {memory}\n"
         self.script += "  input:\n"
-        for input_file in input_files:
-            self.script += f"    path \"{input_file}\"\n"
+        self.script += f"    tuple val( id ), path( \"*\" )\n"
+
+        example_task = physical_tasks[0]
+
         self.script += "  output:\n"
-        for output_file in output_files:
-            self.script += f"    path \"{output_file}\"\n"
+        outstream_contains_infiles = defaultdict(bool)
+        for ptask in physical_tasks:
+            outfile_regex = f"{abstract_task_name}_{ptask.task_id}_(.*)_(\d{{8}})(.*)"
+            for outfile in self.task_outputs[ptask.name]:
+                outfile_search = re.search(outfile_regex, outfile)
+                if outfile_search:
+                    is_infile_aswell = outfile in self.task_inputs[ptask.name]
+                    outstream = (outfile_search.group(1), outfile_search.group(3))
+                    outstream_contains_infiles[outstream] |= is_infile_aswell
+        outstreams = list(outstream_contains_infiles.keys())
+        self.task_outstreams[abstract_task_name] = outstreams
+        for outstream in outstreams:
+            self.script += f"    path( \"{abstract_task_name}_${{id}}_{outstream[0]}_????????{outstream[1]}\""
+            if outstream_contains_infiles[outstream]:
+                self.script += ", includeInputs: true"
+            self.script += " )\n"
+
+        cmd = pathlib.Path(example_task.program).name
+        for a in example_task.args:
+            if a == f"{abstract_task_name}_{example_task.task_id}":
+                cmd += f" {abstract_task_name}_${{id}}"
+                continue
+            cmd += ' '
+            if a.startswith("--out"):
+                cmd += "--out \"{${" + self.valid_task_name(abstract_task_name) + "_out_args.get(id)}}\" \\$inputs"
+                break
+            else:
+                a = a.replace(f"{abstract_task_name}_{example_task.task_id}", f"{abstract_task_name}_${{id}}")
+                cmd += a.replace("'", "\"")
+
         self.script += "\n"
         self.script += "  script:\n"
         self.script += "  \"\"\"\n"
-        self.script += f"  {pathlib.Path(task.program).name}"
-        for a in task.args:
-            self.script += ' '
-            a = a.replace("'", "\"") if "--out" not in a else a.replace("{", "\"{").replace("}", "}\"").replace("'", "\\\\\"").replace(": ", ":")
-            self.script += a
+        self.script += f"  inputs=*{abstract_task_name}_${{id}}*\n"
+        self.script += f"  {cmd}"
         self.script += '\n'
         self.script += "  \"\"\"\n"
         self.script += "}\n"
-
-        self.task_inputs[task.name] = input_files
-        self.task_outputs[task.name] = output_files
-

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -9,14 +9,14 @@
 # (at your option) any later version.
 
 import pathlib
-import re
+import json
 
 from collections import defaultdict
 from logging import Logger
 from typing import Dict, List, Optional, Union, MutableSet
 
 from .abstract_translator import Translator
-from ...common import FileLink, Workflow
+from ...common import File, FileLink, Workflow
 from ...common.task import Task
 
 
@@ -37,26 +37,26 @@ class NextflowTranslator(Translator):
         super().__init__(workflow, logger)
 
         self.script = """
-String extractIDfromFile(Path filepath, String task_name) {
+import groovy.json.JsonSlurper
+def jsonSlurper = new JsonSlurper()
+
+List<String> extractTaskIDforFile(Path filepath, String task_name) {
   String filename = filepath as String
   filename = filename[filename.lastIndexOf('/')+1..-1]
-  
-  int first_id_start = filename.indexOf('0')
-  if (first_id_start < 0) return
-  String first_task_name = filename.substring(0, first_id_start - 1)
-  if (first_task_name == task_name) return filename.substring(first_id_start, first_id_start + 8)
 
-  if (first_id_start + 9 >= filename.length()) return
-
-  int second_id_start = filename.indexOf('0', first_id_start + 8)
-  if (second_id_start < 0) return
-  String second_task_name = filename.substring(first_id_start + 9, second_id_start - 1)
-  if (second_task_name == task_name) return filename.substring(second_id_start, second_id_start + 8)
+  List<String> ids_for_file = new ArrayList<String>()
+  for (destination : file_inputs[filename]) {
+    def destination_task_name = destination[0]
+    def destination_task_id = destination[1]
+    if (destination_task_name == task_name)
+      ids_for_file.add(destination_task_id)
+  }
+  return ids_for_file
 }
 
 """
 
-    def translate(self, output_file_path: pathlib.Path, input_file_directory: pathlib.Path = None) -> None:
+    def translate(self, output_file_path: pathlib.Path) -> None:
         """
         Translate a workflow benchmark description(WfFormat) into a Nextflow workflow application.
 
@@ -64,77 +64,177 @@ String extractIDfromFile(Path filepath, String task_name) {
         : type output_file_path: pathlib.Path
         """
 
-        self.task_inputs: Dict[str, List[str]] = {}
-        self.task_outputs: Dict[str, List[str]] = {}
-
-        self.missing_files = []
-
         # determine the abstract tasks and their abstract parents and children
         self.abstract_tasks = defaultdict(list)
-        self.abstract_children: Dict[str, MutableSet[str]] = defaultdict(set)
         self.abstract_parents: Dict[str, MutableSet[str]] = defaultdict(set)
-        self._determine_abstract_tasks()
+        self._determine_abstract_relations()
 
-        all_inputs = []
-        all_outputs = []
-        for inputs in self.task_inputs.values():
-            all_inputs.extend(inputs)
-        for outputs in self.task_outputs.values():
-            all_outputs.extend(outputs)
-        self.workflow_inputs = [i for i in all_inputs if i not in all_outputs]
+        self.task_inputs: Dict[str, List[File]] = {}
+        self.task_outputs: Dict[str, List[File]] = {}
+        self.task_input_amounts: Dict[str, int] = {}
+        self._determine_input_output()
 
-        self.task_outstreams: Dict = {}
+        self.workflow_inputs = set().union(*self.task_inputs.values()).difference(*self.task_outputs.values())
+
+        self._create_file_task_mappings(output_file_path)
+
         for abstract_task_name, physical_tasks in self.abstract_tasks.items():
-            self._add_output_map(abstract_task_name, physical_tasks)
+            self._create_task_output_map(output_file_path, abstract_task_name, physical_tasks)
+        self.script += "\n\n"
+
         self.task_written: Dict[str, bool] = {}
         for abstract_task_name, physical_tasks in self.abstract_tasks.items():
             self.task_written[abstract_task_name] = False
-            self._add_abstract_task(abstract_task_name, physical_tasks)
+            self._add_abstract_task_definition(abstract_task_name, physical_tasks)
 
         self.script += "workflow {\n"
-        workflow_inputs_path: str = input_file_directory.absolute() if input_file_directory else pathlib.Path("./")
-        for missing_file in self.missing_files:
-            self.script += f"  file(\"{workflow_inputs_path.joinpath(missing_file)}\").text = \"?\"\n"
-        self.script += "\n"
-
-        self.script += f"  workflow_inputs = Channel.fromPath(\"{workflow_inputs_path.joinpath('*')}\")\n"
+        self.script += "  workflow_inputs = Channel.fromPath(\"${params.indir}/*\")\n"
         self.script += "\n"
 
         for abstract_task_name, physical_tasks in self.abstract_tasks.items():
             if not self.task_written[abstract_task_name]:
-                self._write_abstract_task(abstract_task_name, physical_tasks)
-
+                self._add_call_to_abstract_task(abstract_task_name, physical_tasks)
         self.script += "}\n"
 
-        # write script to file
         self._write_output_file(self.script, output_file_path)
 
-    def _add_output_map(self, abstract_task_name: str, physical_tasks: List[Task]) -> None:
-        self.script += f"def {self.valid_task_name(abstract_task_name)}_out_args = [\n"
+    def _determine_abstract_relations(self) -> None:
+        """
+        Determines the abstract tasks that will be used for the nextflow definition of the workflow.
+        """
+
+        for task in self.tasks.values():
+            abstract_task: str = task.category
+            self.abstract_tasks[abstract_task].append(task)
+
+            for parent in self.task_parents[task.name]:
+                abstract_parent: str = self.tasks[parent].category
+                self.abstract_parents[abstract_task].add(abstract_parent)
+
+        tasks_with_iterations = set()
+        for abstract_task in self.abstract_tasks:
+            for abstract_parent in self.abstract_parents[abstract_task]:
+                if abstract_parent == abstract_task:
+                    tasks_with_iterations.add(abstract_task)
+        if tasks_with_iterations:
+            error_msg: str = "Iterations are not supported by Nextflow. "\
+                "Thus, this workflow has no Nextflow translation since the following "\
+                f"{'task uses' if len(tasks_with_iterations) == 1 else 'tasks use'} "\
+                "iterations:\n    "
+            error_msg += ", ".join(tasks_with_iterations)
+            raise RuntimeError(error_msg)
+
+    def _determine_input_output(self) -> None:
+        """
+        Determines the inputs and outputs for the physical and abstract tasks.
+        """
+        for task in self.tasks.values():
+            self.task_inputs[task.name] = [file for file in task.files if file.link == FileLink.INPUT]
+            self.task_outputs[task.name] = [file for file in task.files if file.link == FileLink.OUTPUT]
+
+        self.script += "// define amount of input files for abstracts tasks where the amount is not constant\n"
+        for abstract_task_name, physical_tasks in self.abstract_tasks.items():
+            input_amounts = {task.task_id: len(self.task_inputs[task.name]) for task in physical_tasks}
+            if (max(input_amounts.values()) == min(input_amounts.values())):
+                # all physical tasks have the same amount of inputs
+                self.task_input_amounts[abstract_task_name] = max(input_amounts.values())
+            else:
+                # define amount of inputs for each physical task
+                self.script += f"def {self.valid_task_name(abstract_task_name)}_input_amounts = [\n"
+                for k, v in input_amounts.items():
+                    self.script += f"  \"{k}\": {v},\n"
+                self.script += "]\n"
+                self.task_input_amounts[abstract_task_name] = None
+        self.script += "\n"
+
+    def _create_file_task_mappings(self, output_file_path: pathlib.Path) -> None:
+        file_task_map = defaultdict(list)
+        for task_name, task_input_files in self.task_inputs.items():
+            task = self.tasks[task_name]
+            for file in task_input_files:
+                file_task_map[file.name].append([task.category, task.task_id])
+        self._write_map_file(file_task_map, "file_inputs", output_file_path)
+
+    def _write_map_file(self, map_dict: Dict, map_name: str, output_file_path: pathlib.Path) -> None:
+        path = output_file_path.parent.joinpath(f"{map_name}.json")
+        with open(path, "w") as f:
+            f.write(json.dumps(map_dict, indent=4))
+        self.script += f"{map_name} = jsonSlurper.parseText(file(\"${{params.indir}}/{map_name}.json\").text)\n"
+
+    def _create_task_output_map(self, output_file_path: pathlib.Path, abstract_task_name: str, physical_tasks: List[Task]) -> None:
+        map_name = f"{self.valid_task_name(abstract_task_name)}_out_args"
+        task_output_map = {}
         for ptask in physical_tasks:
-            out_args = [arg for arg in ptask.args if arg.startswith("--out ")]
-            assert (len(out_args) == 1)
-            out_arg = out_args[0].replace("--out {", "").replace("}", "").replace("'", "\\\\\\\"").replace(": ", ":")
-            self.script += f"  \"{ptask.task_id}\": \"{out_arg}\",\n"
-        self.script += "]\n\n"
+            out_file_sizes = {file.name: file.size for file in self.task_outputs[ptask.name]}
+            out_arg = str(out_file_sizes).replace("{", "").replace("}", "").replace("'", "\\\"").replace(": ", ":")
+            task_output_map[ptask.task_id] = out_arg
+        self._write_map_file(task_output_map, map_name, output_file_path)
 
     def valid_task_name(self, original_task_name: str) -> str:
         return original_task_name.replace('-', '_')
 
-    def _write_abstract_task(self, abstract_task_name: str, physical_tasks: List[Task]) -> None:
+    def _add_abstract_task_definition(self, abstract_task_name: str, physical_tasks: List[Task]) -> None:
+        """
+        Add an abstract task to the workflow considering it's physical tasks.
+
+        : param abstract_task_name: the name of the abstract task
+        : type abstract_task_name: str
+        : param physical_tasks: a list of physical tasks for this abstract tasks
+        : type physical_tasks: List[Task]
+        """
+
+        cores_values = [task.cores for task in physical_tasks if task.cores]
+        cores = max(cores_values) if cores_values else None
+        memory_values = [task.memory for task in physical_tasks if task.memory]
+        memory = max(memory_values)*1024 if memory_values else 8 * 1024**3  # default to 8.GB
+
+        example_task = physical_tasks[0]
+
+        cmd = pathlib.Path(example_task.program).name
+        for a in example_task.args:
+            if a == f"{abstract_task_name}_{example_task.task_id}":
+                cmd += f" {abstract_task_name}_${{id}}"
+                continue
+            cmd += ' '
+            if a.startswith("--out"):
+                cmd += "--out \"{${" + self.valid_task_name(abstract_task_name) + "_out_args.get(id)}}\""
+                cmd += " \\$inputs"
+                break
+            else:
+                a = a.replace(f"{abstract_task_name}_{example_task.task_id}", f"{abstract_task_name}_${{id}}")
+                cmd += a.replace("'", "\"")
+
+        self.script += f"process task_{self.valid_task_name(abstract_task_name)}" + " {\n"
+        if cores:
+            self.script += f"  cpus {cores}\n"
+        if memory:
+            self.script += f"  memory {memory}.B\n"
+        self.script += "  input:\n"
+        self.script += f"    tuple val( id ), path( \"*\" )\n"
+
+        self.script += f"  output:\n    path( \"{self.valid_task_name(abstract_task_name)}_????????_outfile_????*\" )\n"
+        self.script += "  script:\n"
+        self.script += "  \"\"\"\n"
+        self.script += f"  inputs=\\$(find . -maxdepth 1 -name \\\"workflow_infile_*\\\" -or -name \\\"*_outfile_0*\\\")\n"
+        self.script += f"  {cmd}\n"
+        self.script += "  \"\"\"\n"
+        self.script += "}\n"
+
+    def _add_call_to_abstract_task(self, abstract_task_name: str, physical_tasks: List[Task]) -> None:
         parents = self.abstract_parents[abstract_task_name]
         for parent in parents:
             if parent == abstract_task_name:
-                continue
+                raise RuntimeError("Iterations are not supported by Nextflow.")
             if not self.task_written[parent]:
-                self._write_abstract_task(parent, self.abstract_tasks[parent])
+                self._add_call_to_abstract_task(parent, self.abstract_tasks[parent])
 
         # determining the channel of all raw inputs (outputs of other tasks)
         input_channels = [
-            f"{self.valid_task_name(parent)}_FOR_{self.valid_task_name(abstract_task_name)}" for parent in parents]
+            f"{self.valid_task_name(parent)}_out" for parent in parents]
         example_task = physical_tasks[0]
+
         for input_file in self.task_inputs[example_task.name]:
-            if input_file in self.workflow_inputs or input_file in self.missing_files:
+            if input_file in self.workflow_inputs:
                 input_channels.append("workflow_inputs")
                 break
 
@@ -149,122 +249,20 @@ String extractIDfromFile(Path filepath, String task_name) {
             raise RuntimeError(f"The abstract task {abstract_task_name} has no inputs.")
 
         # creating the input channel for this abstract task by grouping the outputs from the parents by id
-        self.script += f"  {self.valid_task_name(abstract_task_name)}_in = {inputs_channel}.flatten().map{{\n"
-        self.script += f"    String id = extractIDfromFile(it, \"{abstract_task_name}\")\n"
-        self.script += f"    if (id) return [id, it]\n"
-        self.script += "  }.groupTuple()\n"
+        self.script += f"  {self.valid_task_name(abstract_task_name)}_in = {inputs_channel}.flatten().flatMap{{\n"
+        self.script += f"    List<String> ids = extractTaskIDforFile(it, \"{abstract_task_name}\")\n"
+        self.script += f"    def pairs = new ArrayList()\n"
+        self.script += f"    for (id : ids) pairs.add([id, it])\n"
+        self.script += f"    return pairs\n"
+        self.script += "  }"
 
-        # creating one output channel for each child
-        out_channels = [f"{self.valid_task_name(abstract_task_name)}_FOR_{self.valid_task_name(name)}" for name,
-                        _ in self.task_outstreams[abstract_task_name]]
-        self.script += "  "
-        if len(out_channels) == 1:
-            self.script += f"{out_channels[0]} = "
-        elif len(out_channels) > 1:
-            self.script += f"({', '.join(out_channels)}) = "
-        self.script += f"task_{self.valid_task_name(abstract_task_name)}({self.valid_task_name(abstract_task_name)}_in)\n\n"
+        if self.task_input_amounts[abstract_task_name]:
+            self.script += f".groupTuple(size: {self.task_input_amounts[abstract_task_name]})\n"
+        else:
+            self.script += f".map {{ id, file -> tuple( groupKey(id, {self.valid_task_name(abstract_task_name)}_input_amounts[id]), file ) }}\n"
+            self.script += f"  .groupTuple()\n"
+
+        self.script += f"  {self.valid_task_name(abstract_task_name)}_out = task_"
+        self.script += f"{self.valid_task_name(abstract_task_name)}({self.valid_task_name(abstract_task_name)}_in)\n\n"
 
         self.task_written[abstract_task_name] = True
-
-    def _determine_abstract_tasks(self) -> None:
-        """
-        Determines the abstract tasks that will be used for the nextflow definition of the workflow.
-        """
-
-        abstract_input_amounts = defaultdict(list)
-        abstract_output_amounts = defaultdict(list)
-
-        tasks_with_iterations = set()
-        for task in self.tasks.values():
-            abstract_task: str = task.category
-            self.abstract_tasks[abstract_task].append(task)
-            self.task_inputs[task.name] = [file.name for file in task.files if file.link == FileLink.INPUT]
-            self.task_outputs[task.name] = [file.name for file in task.files if file.link == FileLink.OUTPUT]
-            self.missing_files.extend([filename for filename in self.task_inputs[task.name]
-                                       if filename in self.task_outputs[task.name]])
-            abstract_input_amounts[abstract_task].append(len(self.task_inputs[task.name]))
-            abstract_output_amounts[abstract_task].append(len(self.task_outputs[task.name]))
-
-            for child in self.task_children[task.name]:
-                abstract_child: str = self.tasks[child].category
-                if abstract_child == abstract_task:
-                    tasks_with_iterations.add(abstract_task)
-                self.abstract_children[abstract_task].add(abstract_child)
-            for parent in self.task_parents[task.name]:
-                abstract_parent: str = self.tasks[parent].category
-                if abstract_parent == abstract_task:
-                    tasks_with_iterations.add(abstract_task)
-                self.abstract_parents[abstract_task].add(abstract_parent)
-
-        if tasks_with_iterations:
-            error_msg: str = "Iterations are not supported by Nextflow. "\
-                "Thus, this workflow has no Nextflow translation since the following "\
-                f"{'task uses' if len(tasks_with_iterations) == 1 else 'tasks use'} "\
-                "iterations:\n    "
-            error_msg += ", ".join(tasks_with_iterations)
-            raise RuntimeError(error_msg)
-
-    def _add_abstract_task(self, abstract_task_name: str, physical_tasks: List[Task]) -> None:
-        """
-        Add an abstract task to the workflow considering it's physical tasks.
-
-        : param abstract_task_name: the name of the abstract task
-        : type abstract_task_name: str
-        : param physical_tasks: a list of physical tasks for this abstract tasks
-        : type physical_tasks: List[Task]
-        """
-
-        cores_values = [task.cores for task in physical_tasks if task.cores]
-        cores = max(cores_values) if cores_values else None
-        memory_values = [task.memory for task in physical_tasks if task.memory]
-        memory = f"{max(memory_values)}.KB" if memory_values else "8.GB"
-
-        self.script += f"process task_{self.valid_task_name(abstract_task_name)}" + " {\n"
-        if cores:
-            self.script += f"  cpus {cores}\n"
-        if memory:
-            self.script += f"  memory {memory}\n"
-        self.script += "  input:\n"
-        self.script += f"    tuple val( id ), path( \"*\" )\n"
-
-        example_task = physical_tasks[0]
-
-        self.script += "  output:\n"
-        outstream_contains_infiles = defaultdict(bool)
-        for ptask in physical_tasks:
-            outfile_regex = f"{abstract_task_name}_{ptask.task_id}_(.*)_(\d{{8}})(.*)"
-            for outfile in self.task_outputs[ptask.name]:
-                outfile_search = re.search(outfile_regex, outfile)
-                if outfile_search:
-                    is_infile_aswell = outfile in self.task_inputs[ptask.name]
-                    outstream = (outfile_search.group(1), outfile_search.group(3))
-                    outstream_contains_infiles[outstream] |= is_infile_aswell
-        outstreams = list(outstream_contains_infiles.keys())
-        self.task_outstreams[abstract_task_name] = outstreams
-        for outstream in outstreams:
-            self.script += f"    path( \"{abstract_task_name}_${{id}}_{outstream[0]}_????????{outstream[1]}\""
-            if outstream_contains_infiles[outstream]:
-                self.script += ", includeInputs: true"
-            self.script += " )\n"
-
-        cmd = pathlib.Path(example_task.program).name
-        for a in example_task.args:
-            if a == f"{abstract_task_name}_{example_task.task_id}":
-                cmd += f" {abstract_task_name}_${{id}}"
-                continue
-            cmd += ' '
-            if a.startswith("--out"):
-                cmd += "--out \"{${" + self.valid_task_name(abstract_task_name) + "_out_args.get(id)}}\" \\$inputs"
-                break
-            else:
-                a = a.replace(f"{abstract_task_name}_{example_task.task_id}", f"{abstract_task_name}_${{id}}")
-                cmd += a.replace("'", "\"")
-
-        self.script += "\n"
-        self.script += "  script:\n"
-        self.script += "  \"\"\"\n"
-        self.script += f"  inputs=*{abstract_task_name}_${{id}}*\n"
-        self.script += f"  {cmd}"
-        self.script += '\n'
-        self.script += "  \"\"\"\n"
-        self.script += "}\n"

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -12,6 +12,7 @@ import pathlib
 import json
 
 from collections import defaultdict
+from math import ceil
 from logging import Logger
 from typing import Dict, List, Optional, Union, MutableSet
 
@@ -208,7 +209,7 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         if cores:
             self.script += f"  cpus {cores}\n"
         if memory:
-            self.script += f"  memory {memory}.B\n"
+            self.script += f"  memory {human_readable_memory(memory)}\n"
         self.script += "  input:\n"
         self.script += f"    tuple val( id ), path( \"*\" )\n"
 
@@ -266,3 +267,14 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         self.script += f"{self.valid_task_name(abstract_task_name)}({self.valid_task_name(abstract_task_name)}_in)\n\n"
 
         self.task_written[abstract_task_name] = True
+
+
+def human_readable_memory(mem_bytes: int) -> str:
+    idx = 0
+    memory = mem_bytes
+    l = ["B", "KB", "MB", "GB", "TB"]
+    while memory > 4096 and idx < len(l)-1:
+        memory /= 1024
+        idx += 1
+    memory = ceil(memory * 100) / 100  # ensure that it is an upper bound
+    return f"{memory:.2f}{l[idx]}"

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -195,7 +195,7 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         if len(cores_values) == 0:
             cores = None
         else:
-            cores = int(max(cores_values)) + 1
+            cores = int(max(cores_values))
         memory_values = [task.memory for task in physical_tasks if task.memory is not None]
         if len(memory_values) == 0:
             memory = None

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -212,11 +212,11 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         if memory:
             self.script += f"  memory '{human_readable_memory(memory)}'\n"
         self.script += "  input:\n"
-        self.script += f"    tuple val( id ), path( \"*\" )\n"
+        self.script += "    tuple val( id ), path( \"*\" )\n"
         self.script += f"  output:\n    path( \"{self.valid_task_name(abstract_task_name)}_????????_outfile_????*\" )\n"
         self.script += "  script:\n"
         self.script += "  \"\"\"\n"
-        self.script += f"  inputs=\\$(find . -maxdepth 1 -name \\\"workflow_infile_*\\\" -or -name \\\"*_outfile_0*\\\")\n"
+        self.script += "  inputs=\\$(find . -maxdepth 1 -name \\\"workflow_infile_*\\\" -or -name \\\"*_outfile_0*\\\")\n"
         self.script += f"  {cmd}\n"
         self.script += "  \"\"\"\n"
         self.script += "}\n"
@@ -252,16 +252,16 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         # creating the input channel for this abstract task by grouping the outputs from the parents by id
         self.script += f"  {self.valid_task_name(abstract_task_name)}_in = {inputs_channel}.flatten().flatMap{{\n"
         self.script += f"    List<String> ids = extractTaskIDforFile(it, \"{abstract_task_name}\")\n"
-        self.script += f"    def pairs = new ArrayList()\n"
-        self.script += f"    for (id : ids) pairs.add([id, it])\n"
-        self.script += f"    return pairs\n"
+        self.script += "    def pairs = new ArrayList()\n"
+        self.script += "    for (id : ids) pairs.add([id, it])\n"
+        self.script += "    return pairs\n"
         self.script += "  }"
 
         if self.task_input_amounts[abstract_task_name]:
             self.script += f".groupTuple(size: {self.task_input_amounts[abstract_task_name]})\n"
         else:
             self.script += f".map {{ id, file -> tuple( groupKey(id, {self.valid_task_name(abstract_task_name)}_input_amounts[id]), file ) }}\n"
-            self.script += f"  .groupTuple()\n"
+            self.script += "  .groupTuple()\n"
 
         self.script += f"  {self.valid_task_name(abstract_task_name)}_out = task_"
         self.script += f"{self.valid_task_name(abstract_task_name)}({self.valid_task_name(abstract_task_name)}_in)\n\n"
@@ -272,9 +272,9 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
 def human_readable_memory(mem_bytes: int) -> str:
     idx = 0
     memory = mem_bytes
-    l = ["B", "KB", "MB", "GB", "TB"]
-    while memory > 4096 and idx < len(l)-1:
+    memory_units = ["B", "KB", "MB", "GB", "TB"]
+    while memory > 4096 and idx < len(memory_units) - 1:
         memory /= 1024
         idx += 1
     memory = ceil(memory * 100) / 100  # ensure that it is an upper bound
-    return f"{memory:.2f} {l[idx]}"
+    return f"{memory:.2f} {memory_units[idx]}"

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -210,7 +210,7 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         if cores:
             self.script += f"  cpus {cores}\n"
         if memory:
-            self.script += f"  memory {human_readable_memory(memory)}\n"
+            self.script += f"  memory '{human_readable_memory(memory)}'\n"
         self.script += "  input:\n"
         self.script += f"    tuple val( id ), path( \"*\" )\n"
         self.script += f"  output:\n    path( \"{self.valid_task_name(abstract_task_name)}_????????_outfile_????*\" )\n"
@@ -277,4 +277,4 @@ def human_readable_memory(mem_bytes: int) -> str:
         memory /= 1024
         idx += 1
     memory = ceil(memory * 100) / 100  # ensure that it is an upper bound
-    return f"{memory:.2f}{l[idx]}"
+    return f"{memory:.2f} {l[idx]}"

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -187,10 +187,10 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         cores_values = [task.cores for task in physical_tasks if task.cores]
         cores = max(cores_values) if cores_values else None
         memory_values = [task.memory for task in physical_tasks if task.memory]
-        memory = max(memory_values)*1024 if memory_values else 8 * 1024**3  # default to 8.GB
+        memory = max(memory_values) if memory_values else None
 
+        # creating the command for the abstract task using the first physical task as a template
         example_task = physical_tasks[0]
-
         cmd = pathlib.Path(example_task.program).name
         for a in example_task.args:
             if a == f"{abstract_task_name}_{example_task.task_id}":
@@ -205,6 +205,7 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
                 a = a.replace(f"{abstract_task_name}_{example_task.task_id}", f"{abstract_task_name}_${{id}}")
                 cmd += a.replace("'", "\"")
 
+        # creating the abstract task
         self.script += f"process task_{self.valid_task_name(abstract_task_name)}" + " {\n"
         if cores:
             self.script += f"  cpus {cores}\n"
@@ -212,7 +213,6 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
             self.script += f"  memory {human_readable_memory(memory)}\n"
         self.script += "  input:\n"
         self.script += f"    tuple val( id ), path( \"*\" )\n"
-
         self.script += f"  output:\n    path( \"{self.valid_task_name(abstract_task_name)}_????????_outfile_????*\" )\n"
         self.script += "  script:\n"
         self.script += "  \"\"\"\n"

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -191,12 +191,10 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         : type physical_tasks: List[Task]
         """
 
-        cores_values = [task.cores for task in physical_tasks if task.cores]
-        cores = max(cores_values) if cores_values else None
-        cores = int(cores) + 1 if cores else None
-        memory_values = [task.memory for task in physical_tasks if task.memory]
-        memory = max(memory_values) if memory_values else None
-        memory *= 1.05 if memory else None
+        cores_values = [task.cores for task in physical_tasks]
+        cores = int(max(cores_values)) + 1
+        memory_values = [task.memory for task in physical_tasks]
+        memory = max(memory_values) * 1.05
 
         # creating the command for the abstract task using the first physical task as a template
         example_task = physical_tasks[0]

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -213,7 +213,7 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
             if self._is_resource_arg(a):
                 if resource_args_done:
                     continue
-                cmd += " " + self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"resources\")"
+                cmd += " ${" + self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"resources\")}"
                 resource_args_done = True
             elif a.startswith("--out"):
                 cmd += " --out \"{${" + self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"out\")}}\""

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -100,7 +100,7 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         self._write_output_file(self.script, output_file_path)
 
     def _is_resource_arg(self, arg: str) -> bool:
-        return arg.startswith("--percent_cpu") or arg.startswith("--mem") \
+        return arg.startswith("--percent-cpu") or arg.startswith("--mem") \
             or arg.startswith("--cpu_work") or arg.startswith("--gpu_work")
 
     def _determine_abstract_relations(self) -> None:
@@ -207,10 +207,12 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
                 cmd += f" {abstract_task_name}_${{id}}"
                 continue
             cmd += ' '
-            if not resource_args_done and self._is_resource_arg(a):
-                cmd += self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"resources\")"
+            if self._is_resource_arg(a):
+                if resource_args_done:
+                    continue
+                cmd += self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"resources\") "
                 resource_args_done = True
-            if a.startswith("--out"):
+            elif a.startswith("--out"):
                 cmd += "--out \"{${" + self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"out\")}}\""
                 cmd += " \\$inputs"
                 break

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -164,7 +164,7 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         path = output_file_path.parent.joinpath(f"{map_name}.json")
         with open(path, "w") as f:
             f.write(json.dumps(map_dict, indent=4))
-        self.script += f"{map_name} = jsonSlurper.parseText(file(\"{map_name}.json\").text)\n"
+        self.script += f"{map_name} = jsonSlurper.parseText(file(\"${{projectDir}}/{map_name}.json\").text)\n"
 
     def _create_task_args_map(self, output_file_path: pathlib.Path, abstract_task_name: str, physical_tasks: List[Task]) -> None:
         map_name = f"{self.valid_task_name(abstract_task_name)}_args"

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -101,7 +101,7 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
 
     def _is_resource_arg(self, arg: str) -> bool:
         return arg.startswith("--percent-cpu") or arg.startswith("--mem") \
-            or arg.startswith("--cpu_work") or arg.startswith("--gpu_work")
+            or arg.startswith("--cpu-work") or arg.startswith("--gpu-work")
 
     def _determine_abstract_relations(self) -> None:
         """
@@ -206,19 +206,18 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
             if a == f"{abstract_task_name}_{example_task.task_id}":
                 cmd += f" {abstract_task_name}_${{id}}"
                 continue
-            cmd += ' '
             if self._is_resource_arg(a):
                 if resource_args_done:
                     continue
-                cmd += self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"resources\") "
+                cmd += " " + self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"resources\")"
                 resource_args_done = True
             elif a.startswith("--out"):
-                cmd += "--out \"{${" + self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"out\")}}\""
+                cmd += " --out \"{${" + self.valid_task_name(abstract_task_name) + "_args.get(id).get(\"out\")}}\""
                 cmd += " \\$inputs"
                 break
             else:
                 a = a.replace(f"{abstract_task_name}_{example_task.task_id}", f"{abstract_task_name}_${{id}}")
-                cmd += a.replace("'", "\"")
+                cmd += " " + a.replace("'", "\"")
 
         # creating the abstract task
         self.script += f"process task_{self.valid_task_name(abstract_task_name)}" + " {\n"

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -169,14 +169,14 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
     def _create_task_args_map(self, output_file_path: pathlib.Path, abstract_task_name: str, physical_tasks: List[Task]) -> None:
         map_name = f"{self.valid_task_name(abstract_task_name)}_args"
         task_args_map = {}
-        task_output_map = {}
-        task_resource_map = {}
         for ptask in physical_tasks:
             out_file_sizes = {file.name: file.size for file in self.task_outputs[ptask.name]}
             out_arg = str(out_file_sizes).replace("{", "").replace("}", "").replace("'", "\\\"").replace(": ", ":")
-            task_args_map["out"][ptask.task_id] = out_arg
-            task_args_map["resources"][ptask.task_id] = " ".join((arg for arg in ptask.args if self._is_resource_arg(arg)))
-        self._write_map_file({"out": task_output_map, "resources": task_resource_map}, map_name, output_file_path)
+            task_args_map[ptask.task_id] = {
+                "out": out_arg,
+                "resources": " ".join((arg for arg in ptask.args if self._is_resource_arg(arg)))
+            }
+        self._write_map_file(task_args_map, map_name, output_file_path)
 
     def valid_task_name(self, original_task_name: str) -> str:
         return original_task_name.replace('-', '_')

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -193,8 +193,10 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
 
         cores_values = [task.cores for task in physical_tasks if task.cores]
         cores = max(cores_values) if cores_values else None
+        cores = int(cores) + 1 if cores else None
         memory_values = [task.memory for task in physical_tasks if task.memory]
         memory = max(memory_values) if memory_values else None
+        memory *= 1.05 if memory else None
 
         # creating the command for the abstract task using the first physical task as a template
         example_task = physical_tasks[0]

--- a/wfcommons/wfbench/translator/nextflow.py
+++ b/wfcommons/wfbench/translator/nextflow.py
@@ -191,10 +191,16 @@ List<String> extractTaskIDforFile(Path filepath, String task_name) {
         : type physical_tasks: List[Task]
         """
 
-        cores_values = [task.cores for task in physical_tasks]
-        cores = int(max(cores_values)) + 1
-        memory_values = [task.memory for task in physical_tasks]
-        memory = max(memory_values) * 1.05
+        cores_values = [task.cores for task in physical_tasks if task.cores is not None]
+        if len(cores_values) == 0:
+            cores = None
+        else:
+            cores = int(max(cores_values)) + 1
+        memory_values = [task.memory for task in physical_tasks if task.memory is not None]
+        if len(memory_values) == 0:
+            memory = None
+        else:
+            memory = max(memory_values) * 1.05
 
         # creating the command for the abstract task using the first physical task as a template
         example_task = physical_tasks[0]


### PR DESCRIPTION
This PR adds a translator for the [Nextflow](https://www.nextflow.io/) workflow management system.

## Implementation
The translator defines workflows only by their abstract tasks (wfcommons' `task.category`) allowing Nextflow to deal with the task instances. This requires more code than a brute force solution would, but the result is a Nextflow-like definition of wfcommons workflows using Nextflow's common features like channels.

## Limitations
By using the Nextflow-like way to script a workflow we cannot support iterations (a task depending on another task with the same `task.category`), because Nextflow does not either.

## Discussion
As it is a limitation of Nextflow itself, I did not implement any way of supporting iterations in a workflow, the code raises an error instead. Please tell me if you would like me to change this behavior.

I am interested in any feedback and I will gladly answer questions.