### PR TITLE
Create Benchmarks from Synthetic Workflow Instances

### DIFF
--- a/docs/source/generating_workflow_benchmarks.rst
+++ b/docs/source/generating_workflow_benchmarks.rst
@@ -48,13 +48,33 @@ values for the parameters of the workflow task benchmark can be specified:
 - :code:`percent_cpu`: The fraction of the computation's instructions that
   correspond to non-memory operations. 
 
+Generate from synthetic workflow instances
+++++++++++++++++++++++++++++++++++++++++++
+
+WfCommons also allows you to convert synthetic workflow instances into benchmarks directly.
+The generated benchmark will have exactly the same structure as the synthetic workflow instance.
+
+    import pathlib
+
+    from wfcommons import BlastRecipe
+    from wfcommons.wfbench import WorkflowBenchmark
+
+    # create a synthetic workflow instance with 500 tasks or use one that you already have
+    workflow = BlastRecipe.from_num_tasks(500).build_workflow()
+    # create a workflow benchmark object to generate specifications based on a recipe
+    benchmark = WorkflowBenchmark(recipe=BlastRecipe, num_tasks=500)
+    # generate a specification based on performance characteristics and the structure of the synthetic workflow instance
+    path = benchmark.create_benchmark_from_synthetic_workflow(pathlib.Path("/tmp/"), workflow, cpu_work=100, data=10, percent_cpu=0.6)
+
+This is useful when you want to generate a benchmark with a specific structure or when you want
+benchmarks with the more detailed structure provided by WfChef workflow generation.
 
 Translating Specifications into Benchmark Codes
 -----------------------------------------------
 
 WfCommons provides a collection of translators for executing the benchmarks as actual
 workflow applications. Below, we provide illustrative examples on how to generate 
-workflow benchmakrs for the currently supported workflow systems.
+workflow benchmarks for the currently supported workflow systems.
 
 The :class:`~wfcommons.wfbench.translator.abstract_translator.Translator` class is 
 the foundation for each translator class. This class takes as input either a 

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -115,6 +115,15 @@ class WorkflowBenchmark:
         json_path = save_dir.joinpath(
             f"{self.workflow.name.lower()}-{self.num_tasks}").with_suffix(".json")
 
+        # if no cpu_work is provided, use the maximum runtime of each task as a reference
+        if cpu_work is None:
+            cpu_work = {}
+            for task in self.workflow.tasks.values():
+                if task.category not in cpu_work or task.runtime > cpu_work[task.category]:
+                    cpu_work[task.category] = task.runtime
+            for key in cpu_work.keys():
+                cpu_work[key] *= 1000
+
         cores, lock = self._creating_lock_files(lock_files_folder)
 
         max_runtime = max(task.runtime for task in self.workflow.tasks.values())

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -234,8 +234,7 @@ class WorkflowBenchmark:
             f"{self.workflow.name.lower()}-{self.num_tasks}").with_suffix(".json")
 
         cores, lock = self._creating_lock_files(lock_files_folder)
-        self._set_argument_parameters(
-            percent_cpu, cpu_work, gpu_work, time, mem, lock_files_folder, cores, lock, clear_files=False)
+        self._set_argument_parameters(percent_cpu, cpu_work, gpu_work, time, mem, lock_files_folder, cores, lock)
 
         self._create_data_footprint(data, save_dir)
 

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -162,7 +162,7 @@ class WorkflowBenchmark:
             )
             task.cores = task_cores + 1
             if task_memory:
-                task.memory = task_memory
+                task.memory = task_memory * 1024 * 1024  # megabytes to bytes
 
         # create data footprint
         for task in self.workflow.tasks.values():

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -334,7 +334,7 @@ class WorkflowBenchmark:
         _cpu_work = cpu_work[task.category] if isinstance(
             cpu_work, dict) else cpu_work
 
-        params = [f"--percent-cpu {_percent_cpu}", f"--cpu-work {_cpu_work}"]
+        params = [f"--percent-cpu {_percent_cpu}", f"--cpu-work {int(_cpu_work)}"]
 
         if lock_files_folder:
             params.extend([f"--path-lock {lock}",

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -280,7 +280,7 @@ class WorkflowBenchmark:
         for task in self.workflow.tasks.values():
             params = []
 
-            cpu_params = self._generate_task_cpu_params(task, cpu_work, percent_cpu, lock_files_folder, cores, lock)
+            cpu_params = self._generate_task_cpu_params(task, percent_cpu, cpu_work, lock_files_folder, cores, lock)
             params.extend(cpu_params)
             gpu_params = self._generate_task_gpu_params(task, gpu_work)
             params.extend(gpu_params)

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -116,7 +116,7 @@ class WorkflowBenchmark:
             f"{self.workflow.name.lower()}-{self.num_tasks}").with_suffix(".json")
 
         cores, lock = self._creating_lock_files(lock_files_folder)
-        self._set_argument_parameters(percent_cpu, cpu_work, gpu_work, time, mem, lock_files_folder, cores, lock)
+        self._set_argument_parameters(percent_cpu, cpu_work, gpu_work, time, mem, lock_files_folder, cores, lock, clear_files=False)
 
         for task in self.workflow.tasks.values():
             if mem:

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -157,7 +157,7 @@ class WorkflowBenchmark:
                 cores,
                 lock
             )
-            task.cores = int(10 * task_percent_cpu * runtime_factor)  # set number of cores to cpu threads in wfbench.py
+            task.cores = int(10 * task_percent_cpu)  # set number of cores to cpu threads in wfbench.py
             if task_memory:
                 task.memory = task_memory
 

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -135,6 +135,7 @@ class WorkflowBenchmark:
             task_runtime_factor = task.runtime / task_max_runtimes[task.category]
             # scale argument parameters to achieve a runtime distribution
             task_percent_cpu = percent_cpu[task.category] * task_runtime_factor if isinstance(percent_cpu, dict) else percent_cpu * runtime_factor
+            task_cores = int(10 * task_percent_cpu)  # set number of cores to cpu threads in wfbench.py
             task_percent_cpu = max(0.1, task_percent_cpu)  # set minimum to 0.1 which is equivalent to 1 thread in wfbench.py
             task_percent_cpu = round(task_percent_cpu, 2)
             if cpu_work is not None:
@@ -159,7 +160,7 @@ class WorkflowBenchmark:
                 cores,
                 lock
             )
-            task.cores = int(10 * task_percent_cpu)  # set number of cores to cpu threads in wfbench.py
+            task.cores = task_cores + 1
             if task_memory:
                 task.memory = task_memory
 

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -135,6 +135,7 @@ class WorkflowBenchmark:
             task_runtime_factor = task.runtime / task_max_runtimes[task.category]
             # scale argument parameters to achieve a runtime distribution
             task_percent_cpu = percent_cpu[task.category] * task_runtime_factor if isinstance(percent_cpu, dict) else percent_cpu * runtime_factor
+            task_percent_cpu = max(0.1, percent_cpu)  # set minimum to 0.1 which is equivalent to 1 thread in wfbench.py
             if cpu_work is not None:
                 task_cpu_work = cpu_work[task.category] * task_runtime_factor if isinstance(cpu_work, dict) else cpu_work * runtime_factor
                 task_cpu_work = int(task_cpu_work)

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -135,7 +135,8 @@ class WorkflowBenchmark:
             task_runtime_factor = task.runtime / task_max_runtimes[task.category]
             # scale argument parameters to achieve a runtime distribution
             task_percent_cpu = percent_cpu[task.category] * task_runtime_factor if isinstance(percent_cpu, dict) else percent_cpu * runtime_factor
-            task_percent_cpu = max(0.1, percent_cpu)  # set minimum to 0.1 which is equivalent to 1 thread in wfbench.py
+            task_percent_cpu = max(0.1, task_percent_cpu)  # set minimum to 0.1 which is equivalent to 1 thread in wfbench.py
+            task_percent_cpu = round(task_percent_cpu, 2)
             if cpu_work is not None:
                 task_cpu_work = cpu_work[task.category] * task_runtime_factor if isinstance(cpu_work, dict) else cpu_work * runtime_factor
                 task_cpu_work = int(task_cpu_work)

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -293,7 +293,7 @@ class WorkflowBenchmark:
             task.runtime = 0
             if clear_files:
                 task.files = []
-            task.program = f"{this_dir.joinpath('wfbench.py')}"
+            task.program = "wfbench.py"
             task.args = [task.name]
             task.args.extend(params)
 

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -145,7 +145,7 @@ class WorkflowBenchmark:
                 task_gpu_work = int(task_gpu_work)
             else:
                 task_gpu_work = None
-            task_memory = mem * runtime_factor if mem else None
+            task_memory = int(mem * runtime_factor) if mem else None
             self._set_argument_parameters(
                 task,
                 task_percent_cpu,

--- a/wfcommons/wfbench/wfbench.py
+++ b/wfcommons/wfbench/wfbench.py
@@ -156,20 +156,30 @@ def get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def io_read_benchmark_user_input_data_size(inputs):
+def io_read_benchmark_user_input_data_size(inputs, memory_limit=None):
+    if memory_limit is None:
+        memory_limit = -1
+    memory_limit = int(memory_limit)
     print("[WfBench] Starting IO Read Benchmark...")
     for file in inputs:
         with open(file, "rb") as fp:
             print(f"[WfBench]   Reading '{file}'")
-            fp.readlines()
+            while fp.read(memory_limit):
+                pass
     print("[WfBench] Completed IO Read Benchmark!\n")
 
 
-def io_write_benchmark_user_input_data_size(outputs):
+def io_write_benchmark_user_input_data_size(outputs, memory_limit=None):
+    if memory_limit is None:
+        memory_limit = sys.maxsize
+    memory_limit = int(memory_limit)
     for file_name, file_size in outputs.items():
         print(f"[WfBench] Writing output file '{file_name}'\n")
-        with open(file_name, "wb") as fp:
-            fp.write(os.urandom(int(file_size)))
+        file_size_todo = file_size
+        while file_size_todo > 0:
+            with open(file_name, "ab") as fp:
+                chunk_size = min(file_size_todo, memory_limit)
+                file_size_todo -= fp.write(os.urandom(int(chunk_size)))
 
 
 def main():
@@ -186,7 +196,7 @@ def main():
     print(f"[WfBench] Starting {args.name} Benchmark\n")
 
     if args.out:
-        io_read_benchmark_user_input_data_size(other)
+        io_read_benchmark_user_input_data_size(other, memory_limit=args.mem)
     
     if args.gpu_work:
         print("[WfBench] Starting GPU Benchmark...")
@@ -224,7 +234,7 @@ def main():
 
     if args.out:
         outputs = json.loads(args.out.replace("'", '"'))
-        io_write_benchmark_user_input_data_size(outputs)
+        io_write_benchmark_user_input_data_size(outputs, memory_limit=args.mem)
 
     if core:
         unlock_core(path_locked, path_cores, core)

--- a/wfcommons/wfbench/wfbench.py
+++ b/wfcommons/wfbench/wfbench.py
@@ -195,8 +195,10 @@ def main():
 
     print(f"[WfBench] Starting {args.name} Benchmark\n")
 
+    mem_bytes = args.mem * 1024 * 1024 if args.mem else None
+
     if args.out:
-        io_read_benchmark_user_input_data_size(other, memory_limit=args.mem)
+        io_read_benchmark_user_input_data_size(other, memory_limit=mem_bytes)
     
     if args.gpu_work:
         print("[WfBench] Starting GPU Benchmark...")
@@ -234,7 +236,7 @@ def main():
 
     if args.out:
         outputs = json.loads(args.out.replace("'", '"'))
-        io_write_benchmark_user_input_data_size(outputs, memory_limit=args.mem)
+        io_write_benchmark_user_input_data_size(outputs, memory_limit=mem_bytes)
 
     if core:
         unlock_core(path_locked, path_cores, core)


### PR DESCRIPTION
We, @Lehmann-Fabian and I, propose a new feature which allows to create benchmarks from synthetic workflow instances.

## Idea
Wfcommons' synthetic workflow generation in WfChef features randomly distributed file sizes, and multiple input and output files per tasks which makes them closer to real workflows than the wfcommons benchmarks currently are. Utilizing these great features for benchmark generation allows us to run more realistic experiments with benchmark workflows.
This allows code like the following:
```python
recipe: Type[WfChefWorkflowRecipe] = CyclesRecipe
num_tasks = 200
wf: Workflow = recipe.from_num_tasks(num_tasks).build_workflow()
bm: WorkflowBenchmark = WorkflowBenchmark(recipe, num_tasks)
result_path: Path = bm.create_benchmark_from_synthetic_workflow("/save/dir/path", wf)
```
with a realistic wfcommons benchmark saved at `result_path` which you can then translate to the workflow management system of your choice.

## Implementation
A lot of code from the `create_benchmark` function in `bench.py` can be used for this as well.
Thus, I decided to refactor the parts of `create_benchmark` into multiple smaller functions that can be utilized for the new `create_benchmark_from_synthetic_workflow`. You will find that the interface for all existing functions as well as their behavior is unchanged.
To convert synthetic workflow instances into benchmarks I then also renamed all the files from the synthetic workflow similar to how files are named in wfcommons benchmarks and replaced the task commands with "wfbench.py" and the appropriate arguments.

## Discussion
@Lehmann-Fabian and I will gladly answer any question regarding the motivation for the feature and preferable ways to implement this. We are open to discuss this here or via Zoom.