### PR TITLE
Fix the example to use the 'create_benchmark_from_synthetic_workflow' method and update code snippets' format in the Generating Workflow Benchmarks

### DIFF
--- a/docs/source/generating_workflow_benchmarks.rst
+++ b/docs/source/generating_workflow_benchmarks.rst
@@ -28,6 +28,7 @@ generating workflow benchmarks with an arbitrary number of tasks::
 
     # create a workflow benchmark object to generate specifications based on a recipe
     benchmark = WorkflowBenchmark(recipe=BlastRecipe, num_tasks=500)
+
     # generate a specification based on performance characteristics
     path = benchmark.create_benchmark(pathlib.Path("/tmp/"), cpu_work=100, data=10, percent_cpu=0.6)
 
@@ -52,7 +53,7 @@ Generate from synthetic workflow instances
 ++++++++++++++++++++++++++++++++++++++++++
 
 WfCommons also allows you to convert synthetic workflow instances into benchmarks directly.
-The generated benchmark will have exactly the same structure as the synthetic workflow instance.
+The generated benchmark will have exactly the same structure as the synthetic workflow instance::
 
     import pathlib
 
@@ -95,7 +96,7 @@ Nextflow
 the development of portable and reproducible workflows. It supports deploying workflows
 on a variety of execution platforms including local, HPC schedulers, and cloud-based
 and container-based environments. Below, we provide an example on how to generate
-workflow benchmark for running with Nextflow:
+workflow benchmark for running with Nextflow::
 
     import pathlib
 

--- a/docs/source/generating_workflow_benchmarks.rst
+++ b/docs/source/generating_workflow_benchmarks.rst
@@ -61,10 +61,12 @@ The generated benchmark will have exactly the same structure as the synthetic wo
 
     # create a synthetic workflow instance with 500 tasks or use one that you already have
     workflow = BlastRecipe.from_num_tasks(500).build_workflow()
+
     # create a workflow benchmark object to generate specifications based on a recipe
     benchmark = WorkflowBenchmark(recipe=BlastRecipe, num_tasks=500)
+    
     # generate a specification based on performance characteristics and the structure of the synthetic workflow instance
-    path = benchmark.create_benchmark_from_synthetic_workflow(pathlib.Path("/tmp/"), workflow, cpu_work=100, data=10, percent_cpu=0.6)
+    path = benchmark.create_benchmark_from_synthetic_workflow(pathlib.Path("/tmp/"), workflow, cpu_work=100, percent_cpu=0.6)
 
 This is useful when you want to generate a benchmark with a specific structure or when you want
 benchmarks with the more detailed structure provided by WfChef workflow generation.

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -276,7 +276,7 @@ class WorkflowBenchmark:
             f"{self.workflow.name.lower()}-{self.num_tasks}").with_suffix(".json")
 
         cores, lock = self._creating_lock_files(lock_files_folder)
-        for task in self.tasks.values():
+        for task in self.workflow.tasks.values():
             self._set_argument_parameters(
                 task,
                 percent_cpu,


### PR DESCRIPTION
The example of usage of the `create_benchmark_from_synthetic_workflow` method was passing `data` as an argument, but it is not defined inside the method ans causes an error;

A few code snippets were not being showed in the correct format.