### PR TITLE
Fix the path to find the `cpu-benchmark` and `gpu-benchmark` files

### DIFF
--- a/wfcommons/wfbench/wfbench.py
+++ b/wfcommons/wfbench/wfbench.py
@@ -23,7 +23,7 @@ from io import StringIO
 from filelock import FileLock
 from typing import List, Optional
 
-bin_dir = pathlib.Path("../../bin")
+this_dir = pathlib.Path(__file__).resolve().parent
 
 def lock_core(path_locked: pathlib.Path,
               path_cores: pathlib.Path) -> int:
@@ -113,11 +113,12 @@ def cpu_mem_benchmark(cpu_threads: Optional[int] = 5,
 
     cpu_procs = []
     cpu_prog = [
-        f"{bin_dir.joinpath('cpu-benchmark')}", f"{cpu_work_per_thread}"]
+        f"{this_dir.parent.parent.joinpath('bin').joinpath('cpu-benchmark')}", f"{cpu_work_per_thread}"]
     mem_prog = ["stress-ng", "--vm", f"{mem_threads}",
                 "--vm-bytes", f"{total_mem}", "--vm-keep"]
 
     for i in range(cpu_threads):
+        print(cpu_prog)
         cpu_proc = subprocess.Popen(cpu_prog)
         if core:
             os.sched_setaffinity(cpu_proc.pid, {core})
@@ -136,7 +137,7 @@ def get_available_gpus():
     return df[df["utilization.gpu"] <= 5].index.to_list()
 
 def gpu_benchmark(work, device):
-    gpu_prog = [f"CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES={device} {bin_dir.joinpath('gpu-benchmark')} {work}"]
+    gpu_prog = [f"CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES={device} {this_dir.parent.parent.joinpath('bin').joinpath('gpu-benchmark')} {work}"]
     subprocess.Popen(gpu_prog, shell=True)  
 
 def get_parser() -> argparse.ArgumentParser:

--- a/wfcommons/wfbench/wfbench.py
+++ b/wfcommons/wfbench/wfbench.py
@@ -23,7 +23,6 @@ from io import StringIO
 from filelock import FileLock
 from typing import List, Optional
 
-this_dir = pathlib.Path(__file__).resolve().parent
 bin_dir = pathlib.Path("../../bin")
 
 def lock_core(path_locked: pathlib.Path,
@@ -137,7 +136,7 @@ def get_available_gpus():
     return df[df["utilization.gpu"] <= 5].index.to_list()
 
 def gpu_benchmark(work, device):
-    gpu_prog = [f"CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES={device} {this_dir.joinpath('gpu-benchmark')} {work}"]
+    gpu_prog = [f"CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES={device} {bin_dir.joinpath('gpu-benchmark')} {work}"]
     subprocess.Popen(gpu_prog, shell=True)  
 
 def get_parser() -> argparse.ArgumentParser:

--- a/wfcommons/wfbench/wfbench.py
+++ b/wfcommons/wfbench/wfbench.py
@@ -24,7 +24,7 @@ from filelock import FileLock
 from typing import List, Optional
 
 this_dir = pathlib.Path(__file__).resolve().parent
-
+bin_dir = pathlib.Path("../../bin")
 
 def lock_core(path_locked: pathlib.Path,
               path_cores: pathlib.Path) -> int:
@@ -114,7 +114,7 @@ def cpu_mem_benchmark(cpu_threads: Optional[int] = 5,
 
     cpu_procs = []
     cpu_prog = [
-        f"{this_dir.joinpath('cpu-benchmark')}", f"{cpu_work_per_thread}"]
+        f"{bin_dir.joinpath('cpu-benchmark')}", f"{cpu_work_per_thread}"]
     mem_prog = ["stress-ng", "--vm", f"{mem_threads}",
                 "--vm-bytes", f"{total_mem}", "--vm-keep"]
 


### PR DESCRIPTION
I was trying to run `wfbench.py` alone to understand how it works, by executing `python3 wfbench.py split_fasta_00000001 --percent-cpu 0.6 --cpu-work 400 './split_fasta_00000001_input.txt'` and I got the following problem:

```
python3 wfbench.py split_fasta_00000001 --percent-cpu 0.6 --cpu-work 400 './split_fasta_00000001_input.txt'
[WfBench] Starting split_fasta_00000001 Benchmark

[WfBench] Starting CPU and Memory Benchmarks...
['<my-path>/WfCommons/wfcommons/wfbench/cpu-benchmark', '21']
Traceback (most recent call last):
  File "<my-path>/WfCommons/wfcommons/wfbench/wfbench.py", line 254, in <module>
    main()
  File "<my-path>/WfCommons/wfcommons/wfbench/wfbench.py", line 225, in main
    cpu_procs = cpu_mem_benchmark(cpu_threads=int(10 * args.percent_cpu),
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<my-path>/WfCommons/wfcommons/wfbench/wfbench.py", line 128, in cpu_mem_benchmark
    cpu_proc = subprocess.Popen(cpu_prog)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1024, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.11/subprocess.py", line 1901, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '<my-path>/WfCommons/wfcommons/wfbench/cpu-benchmark'
```

I identified that the `cpu-benchmark` is not inside the `wfbench` directory, but two directories back on `<my-path>/WfCommons/bin/. So I updated the way this path was created.

I modified the `wfbench.py` from this:
```
   cpu_prog = [f"{this_dir.joinpath('cpu-benchmark')}", f"{cpu_work_per_thread}"]
   ...
   gpu_prog = [f"CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES={device} {this_dir.joinpath('gpu-benchmark')} {work}"]

```

To this:
```
   cpu_prog = [f"{this_dir.parent.parent.joinpath('bin').joinpath('cpu-benchmark')}", f"{cpu_work_per_thread}"]
   ...
   gpu_prog = [f"CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES={device} {this_dir.parent.parent.joinpath('bin').joinpath('gpu-benchmark')} {work}"]
```