### PR TITLE
Update generating_workflow_benchmarks.rst

### DIFF
--- a/docs/source/generating_workflow_benchmarks.rst
+++ b/docs/source/generating_workflow_benchmarks.rst
@@ -109,7 +109,7 @@ workflow benchmark for running with Nextflow::
 
     # generate a Nextflow workflow
     translator = NextflowTranslator(benchmark.workflow)
-    translator.translate(output_file_name=pathlib.Path("/tmp/benchmark-workflow.nf"))
+    translator.translate(output_file_path=pathlib.Path("/tmp/benchmark-workflow.nf"))
 
 .. warning::
 


### PR DESCRIPTION
Fixes the parameter of translator.translate(output_file_name=pathlib.Path("/tmp/benchmark-workflow.nf")). The correct parameter name is output_file_path