### PR TITLE
fix several bugs within wfbench (and a minor one for wfchef)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "filelock",
     "pathos",
 ]
-dynamic = ["version"]
+dynamic = ["version", "entry-points", "scripts"]
 
 [project.urls]
 Homepage = "https://wfcommons.org"

--- a/wfcommons/common/workflow.py
+++ b/wfcommons/common/workflow.py
@@ -83,6 +83,7 @@ class Workflow(nx.DiGraph):
         self.tasks_parents = {}
         self.tasks_children = {}
         self.workflow_id: str = None
+        self.workflow_json = {}
         super().__init__(name=name, makespan=self.makespan, executedat=self.executed_at)
 
     def add_task(self, task: Task) -> None:
@@ -116,6 +117,22 @@ class Workflow(nx.DiGraph):
 
         :param json_file_path: JSON output file name.
         :type json_file_path: Optional[pathlib.Path]
+        """
+
+        self.generate_json()
+
+         # write to file
+        if not json_file_path:
+            json_file_path = pathlib.Path(f"{self.name.lower()}.json")
+        with open(json_file_path, "w") as outfile:
+            outfile.write(json.dumps(self.workflow_json, indent=4))
+
+    def generate_json(self) -> dict:
+        """
+        Generate a JSON representation of the workflow instance.
+
+        :return: A JSON representation of the workflow instance.
+        :rtype: dict
         """
         workflow_machines = []
         machines_list = []
@@ -191,12 +208,6 @@ class Workflow(nx.DiGraph):
         if files and len(files) > 0:
             workflow_json["workflow"]["specification"]["files"] = list(file.as_dict() for file in files)
 
-        # write to file
-        if not json_file_path:
-            json_file_path = pathlib.Path(f"{self.name.lower()}.json")
-        with open(json_file_path, "w") as outfile:
-            outfile.write(json.dumps(workflow_json, indent=4))
-        
         self.workflow_json = workflow_json
 
     def write_dot(self, dot_file_path: Optional[pathlib.Path] = None) -> None:

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -211,7 +211,8 @@ class WorkflowBenchmark:
         workflow_inputs: List[File] = []
     
         for task in self.workflow.tasks.values():
-            for file in task.output_files:       
+            output_files = sorted(task.output_files, key=lambda x: -len(x.file_id))
+            for file in output_files:
                 if file.file_id in new_file_names:
                     raise ValueError(f"File name {file.file_id} already exists")
                 
@@ -225,7 +226,8 @@ class WorkflowBenchmark:
                 file.file_id = new_name
 
         for task in self.workflow.tasks.values():
-            for file in task.input_files:
+            input_files = sorted(task.input_files, key=lambda x: -len(x.file_id))
+            for file in input_files:
                 org_name = file.file_id
                 if file.file_id in new_file_names:
                     # file is an output file of another task and receives the corresponding name

--- a/wfcommons/wfbench/translator/abstract_translator.py
+++ b/wfcommons/wfbench/translator/abstract_translator.py
@@ -100,14 +100,21 @@ class Translator(ABC):
         :param output_folder: The path to the folder in which the workflow benchmark will be generated.
         :type output_folder: pathlib.Path
         """
-        generated_files = []
+        workflow_input_files = []
+        input_files = set()
+        output_files = set()
+
+        for task in self.workflow.tasks.values():
+            for file in task.input_files:
+                input_files.add(file)
+            for file in task.output_files:
+                output_files.add(file)
+        
+        workflow_input_files = input_files - output_files
+
         data_folder = output_folder.joinpath("data")
         data_folder.mkdir(exist_ok=True)
-        for task_name in self.root_task_names:
-            task = self.tasks[task_name]
-            for file in task.input_files:
-                if file.file_id not in generated_files:
-                    generated_files.append(file.file_id)
+        for file in workflow_input_files:
                     with open(data_folder.joinpath(file.file_id), "wb") as fp:
                         fp.write(os.urandom(int(file.size)))
 

--- a/wfcommons/wfbench/translator/abstract_translator.py
+++ b/wfcommons/wfbench/translator/abstract_translator.py
@@ -44,7 +44,7 @@ class Translator(ABC):
             instance = Instance(workflow, logger=logger)
             self.workflow: Workflow = instance.workflow
 
-        self.workflow.write_json()
+        self.workflow.generate_json()
 
         # find all tasks
         self.tasks = {}


### PR DESCRIPTION
Major bugs
- sorted files by decreasing file_id lengh when renaming files to wfbench format to prevent partial/duplicate replacements (e.g. renaming a file call "input_01" before "input_01.txt")
- fixed bugs where inputs to the workflow (i.e. not produced by any task) is sometimes not generated due to only checking input files of root tasks

Minor bugs
- added a generate_json function, so then each translator wouldn't always write a workflow json in the current working directory when all it needs is the workflow_json obj
- made a change to pyproject.toml, since wfchef weren't being registered as an executable