### PR TITLE
BUG: fixed incorrect template name and removed redundant code

### DIFF
--- a/wfcommons/wfbench/translator/cwl.py
+++ b/wfcommons/wfbench/translator/cwl.py
@@ -132,7 +132,7 @@ class CWLTranslator(Translator):
 
                 code = [
                     f"  {task.task_id}:",
-                    "    run: clt/bash.cwl",
+                    "    run: clt/shell.cwl",
                     "    in:",
                 ]
 
@@ -224,7 +224,7 @@ class CWLTranslator(Translator):
         clt_folder.mkdir(exist_ok=True)
         shutil.copy(this_dir.joinpath("templates/cwl_templates/wfbench.cwl"), clt_folder)
         shutil.copy(this_dir.joinpath("templates/cwl_templates/folder.cwl"), clt_folder)
-        shutil.copy(this_dir.joinpath("templates/cwl_templates/bash.cwl"), clt_folder)
+        shutil.copy(this_dir.joinpath("templates/cwl_templates/shell.cwl"), clt_folder)
 
         with open(cwl_folder.joinpath("main.cwl"), "w", encoding="utf-8") as f:
             f.write("\n".join(self.cwl_script))

--- a/wfcommons/wfbench/translator/templates/cwl_templates/shell.cwl
+++ b/wfcommons/wfbench/translator/templates/cwl_templates/shell.cwl
@@ -6,23 +6,12 @@ requirements:
 stdout: $(inputs.step_name + ".out")
 stderr: $(inputs.step_name + ".err")
 
-arguments:
-  - position: 1
-    valueFrom: >
-      ${
-        var cmd = inputs.command;
-        if (inputs.input_files) {
-          for (var i = 0; i < inputs.input_files.length; i++) {
-            cmd = cmd.replace(new RegExp(inputs.input_files[i].basename, 'g'), inputs.input_files[i].path);
-          }
-        }
-        return cmd;
-      }
-    shellQuote: false
-
 inputs:
   command:
     type: string
+    inputBinding:
+      position: 1
+      shellQuote: false
   input_files:
     type: File[]?
   output_filenames:

--- a/wfcommons/wfbench/translator/templates/cwl_templates/shell.cwl
+++ b/wfcommons/wfbench/translator/templates/cwl_templates/shell.cwl
@@ -3,8 +3,8 @@ class: CommandLineTool
 requirements:
   InlineJavascriptRequirement: {}
   ShellCommandRequirement: {}
-stdout: $("logs/" + inputs.step_name + ".out")
-stderr: $("logs/" + inputs.step_name + ".err")
+stdout: $(inputs.step_name + ".out")
+stderr: $(inputs.step_name + ".err")
 
 arguments:
   - position: 1


### PR DESCRIPTION
- Fixed a bug where the template name is shell.cwl, but I wrote bash.cwl.
- Removed a section of redundant code since cwl runs code in an isolated environment with file staging, so replacing file paths with absolute paths is not necessary.
