### PR TITLE
Simplified the data footprint specification for benchmark generation

### DIFF
--- a/tests/wfbench/test_wfbench.py
+++ b/tests/wfbench/test_wfbench.py
@@ -142,10 +142,6 @@ class TestWfBench:
 
         # Create the data_specification options
         fixed_total_footprint_in_mb = 5
-        # TODO: This seems really broken right now
-        # per_type_footprint = {}
-        # for task_type in ["blastall", "split_fasta", None]:
-        #         per_type_footprint[task_type] = "1" # string???
 
         for data_spec in [fixed_total_footprint_in_mb]:
             benchmark.create_benchmark(_create_fresh_local_dir(f"/tmp/benchmark"), cpu_work=1, data=data_spec, percent_cpu=0.6)

--- a/tests/wfbench/test_wfbench.py
+++ b/tests/wfbench/test_wfbench.py
@@ -148,7 +148,6 @@ class TestWfBench:
         #         per_type_footprint[task_type] = "1" # string???
 
         for data_spec in [fixed_total_footprint_in_mb]:
-            sys.stderr.write(f"TESTING create_benchmark\n")
             benchmark.create_benchmark(_create_fresh_local_dir(f"/tmp/benchmark"), cpu_work=1, data=data_spec, percent_cpu=0.6)
 
             # Run the benchmark with the Bash translator

--- a/tests/wfbench/test_wfbench.py
+++ b/tests/wfbench/test_wfbench.py
@@ -148,6 +148,7 @@ class TestWfBench:
         #         per_type_footprint[task_type] = "1" # string???
 
         for data_spec in [fixed_total_footprint_in_mb]:
+            sys.stderr.write(f"TESTING create_benchmark\n")
             benchmark.create_benchmark(_create_fresh_local_dir(f"/tmp/benchmark"), cpu_work=1, data=data_spec, percent_cpu=0.6)
 
             # Run the benchmark with the Bash translator

--- a/wfcommons/wfbench/bench.py
+++ b/wfcommons/wfbench/bench.py
@@ -541,7 +541,6 @@ class WorkflowBenchmark:
                     task.output_files.append(
                         File(f"{task.task_id}_{child}_output.txt", file_size))
             elif isinstance(output_files, int):
-                sys.stderr.write(f"Adding output file {task.task_id}_output.txt to task {task.task_id}\n")
                 task.output_files.append(
                     File(f"{task.task_id}_output.txt", output_files))
 
@@ -554,12 +553,9 @@ class WorkflowBenchmark:
         :param data: Either a single size or a specification on specific files
         :type data: Union[int, Dict[str, str]]
         """
-        sys.stderr.write(f"IN _add_input_files(): len(output_files)={len(output_files)}\n")
-
         for task in self.workflow.tasks.values():
             inputs = []
             if not self.workflow.tasks_parents[task.task_id]:
-                sys.stderr.write(f"Adding input file {task.task_id}_input.txt to task {task.task_id}\n")
                 task.input_files.append(
                     File(f"{task.task_id}_input.txt",
                          data[task.category] if isinstance(
@@ -582,7 +578,6 @@ class WorkflowBenchmark:
 
                 elif isinstance(data, int):
                     for parent in self.workflow.tasks_parents[task.task_id]:
-                        sys.stderr.write(f"Adding input file {parent}_output.txt to task {task.task_id}\n")
                         task.input_files.append(
                             File(f"{parent}_output.txt", data))
                         inputs.append(f"{parent}_output.txt")


### PR DESCRIPTION
  - Removed the option to specify category-based data footprint when generating benchmark (which was hard to use and incorrectly implemented)
  - Only a single "size in MB" can now be specified