### PR TITLE
Fix RnaseqRecipe import error

### DIFF
--- a/wfcommons/__init__.py
+++ b/wfcommons/__init__.py
@@ -16,7 +16,7 @@ __credits__ = 'University of Hawaii at Manoa, Oak Ridge National Laboratoy, San 
 import logging
 
 from .wfchef.recipes import BlastRecipe, BwaRecipe, CyclesRecipe, EpigenomicsRecipe, GenomeRecipe, MontageRecipe, \
-    SeismologyRecipe, SoykbRecipe, SrasearchRecipe
+    RnaseqRecipe, SeismologyRecipe, SoykbRecipe, SrasearchRecipe
 from .wfgen import WorkflowGenerator
 from .wfinstances import Instance, InstanceAnalyzer, InstanceElement
 


### PR DESCRIPTION
Issue:
Getting an "ImportError: cannot import name 'RnaseqRecipe' from 'wfcommons" when tried to do the import specified below.
"from wfcommons import RnaseqRecipe"

Cause:
In wfcommons/__init__.py file the "RnaseqRecipe" is missing in the list of .wfchef.recipes imported.

Fix:
Added the "RnaseqRecipe to the .wfchef.recipes import list in wfcommons/__init__.py file.
