### PR TITLE
Update permissions to get tests passing on my local machine

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,6 +20,11 @@ from docker.errors import ImageNotFound
 
 from wfcommons.common import Workflow
 
+def _recursive_chmod(dirpath, permissions):
+            for directory, directory_name, filenames in os.walk(dirpath):
+                os.chmod(directory, permissions)
+                for filename in filenames:
+                    os.chmod(os.path.join(directory, filename), permissions)
 
 def _create_fresh_local_dir(path: str) -> pathlib.Path:
     dirpath = pathlib.Path(path)
@@ -89,6 +94,7 @@ def _start_docker_container(backend, mounted_dir, working_dir, bin_dir, command=
         volumes={mounted_dir: {'bind': mounted_dir, 'mode': 'rw'}},
         working_dir=working_dir,
         user="wfcommons",
+        privileged=True,
         tty=True,
         detach=True
     )

--- a/tests/translators_loggers/test_translators_loggers.py
+++ b/tests/translators_loggers/test_translators_loggers.py
@@ -17,6 +17,7 @@ import time
 import re
 import os
 
+from tests.test_helpers import _recursive_chmod
 from tests.test_helpers import _create_fresh_local_dir
 from tests.test_helpers import _remove_local_dir_if_it_exists
 from tests.test_helpers import _start_docker_container
@@ -304,10 +305,7 @@ class TestTranslators:
 
         # Make the directory that holds the translation world-writable,
         # so that we don't have any permission shenanigans
-        for directory, directory_name, filenames in os.walk(dirpath):
-            os.chmod(directory, 0o777)
-            for filename in filenames:
-                os.chmod(os.path.join(directory, filename), 0o777)
+        _recursive_chmod(dirpath, 0o777)
 
         # Start the Docker container
         container = _start_docker_container(backend if backend != "nextflow_subworkflow" else "nextflow", str_dirpath, str_dirpath, str_dirpath + "bin/")

--- a/tests/wfbench/test_wfbench.py
+++ b/tests/wfbench/test_wfbench.py
@@ -15,6 +15,7 @@ import sys
 import json
 import networkx
 
+from tests.test_helpers import _recursive_chmod
 from tests.test_helpers import _create_fresh_local_dir
 from tests.test_helpers import _start_docker_container
 from tests.test_helpers import _shutdown_docker_container_and_remove_image
@@ -157,6 +158,10 @@ class TestWfBench:
             sys.stderr.write("\nTranslating workflow...\n")
             translator = BashTranslator(benchmark.workflow)
             translator.translate(output_folder=dirpath)
+
+            # Make the directory world-writable so that
+            # we don't have any permission shenanigans
+            _recursive_chmod(dirpath, 0o777)
 
             # Start the Docker container
             sys.stderr.write("Starting Docker container...\n")


### PR DESCRIPTION
Changes required to get tests passing on my laptop, possibly caused by Docker version 29.3.0.

In test_wfbench, make tmp directory world-readable so the container can write data files. I made a helper function to avoid duplicating code.

For test_translators_loggers, I had to add `privileges=True` to allow the container to run os.kill.