### PR TITLE
Update cpu_work_per_thread calculation to better match cpu-benchmark

### DIFF
--- a/bin/wfbench
+++ b/bin/wfbench
@@ -186,7 +186,7 @@ class CPUBenchmark:
             return [None, None]
 
         total_mem = f"{self.total_mem}B" if self.total_mem else f"{100.0 / os.cpu_count()}%"
-        cpu_work_per_thread = int(1000000 * self.work / (16384 * self.cpu_threads)) if self.cpu_threads != 0 else int32_max ** 2
+        cpu_work_per_thread = int(1000000 * self.work / self.cpu_threads) if self.cpu_threads != 0 else int32_max ** 2
         cpu_samples = min(cpu_work_per_thread, int32_max)
         cpu_ops = (cpu_work_per_thread + int32_max - 1) // int32_max
         if cpu_ops > int32_max:


### PR DESCRIPTION
cpu-benchmark calculated 1000000 points per unit of cpu_work. In contrast, stress-ng's input is in units of 1 point.

I thought stress-ng batched the calculation in units of 16384 points, but that doesn't appear to be the case.
https://github.com/ColinIanKing/stress-ng/blob/c6952a9ececa120975f84f3ca969bd3c258c77ef/stress-monte-carlo.c#L333