### PR TITLE
matplotlib API change

### DIFF
--- a/wfcommons/wfchef/utils.py
+++ b/wfcommons/wfchef/utils.py
@@ -11,12 +11,12 @@
 import json
 import pathlib
 
+import matplotlib as mpl
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import networkx as nx
 
 from hashlib import sha256
-from matplotlib import cm
 from typing import Iterable, Union, Set, Optional, Tuple, Hashable
 
 this_dir = pathlib.Path(__file__).resolve().parent
@@ -213,7 +213,7 @@ def draw(g: nx.DiGraph,
         node_border_colors.get(src) if node_border_colors.get(src, -1) == node_border_colors.get(dst, 1) else "black"
         for src, dst in g.edges
     ]
-    cmap = cm.get_cmap('rainbow', len(type_set))
+    cmap = mpl.colormaps['rainbow'].resampled(len(type_set))
     nx.draw(g, pos, node_size=node_size, node_color=node_color, edgecolors=edgecolors, edge_color=edge_color,
             linewidths=linewidths, cmap=cmap, ax=ax, with_labels=with_labels)
     color_lines = [mpatches.Patch(color=cmap(types[t]), label=t) for t in type_set]


### PR DESCRIPTION
matplotlib.cm.get_cmap was [deprecated in 3.7](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#deprecation-of-top-level-cmap-registration-and-access-functions-in-mpl-cm) and [removed in 3.11](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.11.0.html#matplotlib-cm-get-cmap). Our CI is now failing, so I changed it to the call recommended in https://github.com/nipreps/nifreeze/issues/444.

