### PR TITLE
RO-Crate log parser generates wfchef-friendly task names/IDs

### DIFF
--- a/wfcommons/wfinstances/logs/ro_crate.py
+++ b/wfcommons/wfinstances/logs/ro_crate.py
@@ -160,6 +160,7 @@ class ROCrateLogsParser(LogsParser):
         # Object to track task's "instrument" for further dependencies
         instruments = {}
 
+        task_idx = 1
         for create_action in create_actions:
             # Handle overall workflow create_action then skip
             if create_action["name"] == f"Run of workflow/{main_workflow_id}":
@@ -202,7 +203,9 @@ class ROCrateLogsParser(LogsParser):
             if not start_time or not end_time:
                 start_time, end_time = self.task_runtimes.get(create_action['name'], (None, None))
 
-            task_id = self._sanitize_task_id(create_action['name'] + "_" + create_action['@id'])
+            # task_id = self._sanitize_task_id(create_action['name'] + "_" + create_action['@id'])
+            task_id = self._sanitize_task_id(create_action['name'] + f"_ID{task_idx:07d}")
+            task_idx += task_idx
 
             task = Task(name=create_action['name'],
                         # task_id=create_action['name'],

--- a/wfcommons/wfinstances/logs/ro_crate.py
+++ b/wfcommons/wfinstances/logs/ro_crate.py
@@ -205,7 +205,7 @@ class ROCrateLogsParser(LogsParser):
 
             # task_id = self._sanitize_task_id(create_action['name'] + "_" + create_action['@id'])
             task_name = self._sanitize_task_id(create_action['name'] + f"_ID{task_idx:07d}")
-            task_id = f"_ID{task_idx:07d}"
+            task_id = task_name
             task_idx += task_idx
 
             task = Task(#name=create_action['name'],

--- a/wfcommons/wfinstances/logs/ro_crate.py
+++ b/wfcommons/wfinstances/logs/ro_crate.py
@@ -204,10 +204,12 @@ class ROCrateLogsParser(LogsParser):
                 start_time, end_time = self.task_runtimes.get(create_action['name'], (None, None))
 
             # task_id = self._sanitize_task_id(create_action['name'] + "_" + create_action['@id'])
-            task_id = self._sanitize_task_id(create_action['name'] + f"_ID{task_idx:07d}")
+            task_name = self._sanitize_task_id(create_action['name'] + f"_ID{task_idx:07d}")
+            task_id = f"_ID{task_idx:07d}"
             task_idx += task_idx
 
-            task = Task(name=create_action['name'],
+            task = Task(#name=create_action['name'],
+                        name=task_name,
                         # task_id=create_action['name'],
                         task_id=task_id,
                         task_type=TaskType.COMPUTE,

--- a/wfcommons/wfinstances/logs/ro_crate.py
+++ b/wfcommons/wfinstances/logs/ro_crate.py
@@ -204,6 +204,7 @@ class ROCrateLogsParser(LogsParser):
                 start_time, end_time = self.task_runtimes.get(create_action['name'], (None, None))
 
             # task_id = self._sanitize_task_id(create_action['name'] + "_" + create_action['@id'])
+            # Using this name/id scheme below is WfChef-friendly
             task_name = self._sanitize_task_id(create_action['name'] + f"_ID{task_idx:07d}")
             task_id = task_name
             task_idx += task_idx


### PR DESCRIPTION
This is a very small PR in which the RO-Crate log parser is modified to generate WfChef-friendly task names and IDs that will allow using WfChef (i.e., both identical, of the form ".*_ID[0-9]*"