### PR TITLE
Snakemake log parser generates Wfbench-friendly task names/ids

### DIFF
--- a/wfcommons/wfinstances/logs/snakemake.py
+++ b/wfcommons/wfinstances/logs/snakemake.py
@@ -158,7 +158,7 @@ class SnakemakeLogsParser(LogsParser):
             if rule_idx not in rules:
                 continue
             # self.task_map[task_idx] = rules[rule_idx] + "_" + str(task_idx)
-            self.task_map[task_idx] = rules[rule_idx] + f"ID_{task_idx:07d}"
+            self.task_map[task_idx] = rules[rule_idx] + f"_ID{task_idx:07d}"
 
             self.task_shell[task_idx] = shell_cmd
             self.task_threads[task_idx] = threads

--- a/wfcommons/wfinstances/logs/snakemake.py
+++ b/wfcommons/wfinstances/logs/snakemake.py
@@ -157,7 +157,9 @@ class SnakemakeLogsParser(LogsParser):
                 shell_cmd = None
             if rule_idx not in rules:
                 continue
-            self.task_map[task_idx] = rules[rule_idx] + "_" + str(task_idx)
+            # self.task_map[task_idx] = rules[rule_idx] + "_" + str(task_idx)
+            self.task_map[task_idx] = rules[rule_idx] + f"ID_{task_idx:07d}"
+
             self.task_shell[task_idx] = shell_cmd
             self.task_threads[task_idx] = threads
             self.task_input_files[task_idx] = []


### PR DESCRIPTION
A tiny PR to make the Snakemake log parser generate WfBench-friendly task names/ids